### PR TITLE
US9: As a developer, I want to create ScriptableObject-based event channels...

### DIFF
--- a/Assets/Scripts/Events/EventChannel.cs
+++ b/Assets/Scripts/Events/EventChannel.cs
@@ -1,12 +1,41 @@
 using UnityEngine;
 using System;
+using System.Collections.Generic;
 
 public class EventChannel<T> : ScriptableObject
 {
-    private event Action<T> OnEventRaised;
+    private readonly List<Action<T>> listeners = new List<Action<T>>();
 
-    public void Subscribe(Action<T> listener) {}
-    public void Unsubscribe(Action<T> listener) {}
-    public void RaiseEvent(T data) {}
-    public void ClearAllListeners() {}
+    public void Subscribe(Action<T> listener)
+    {
+        if (listener == null)
+        {
+            Debug.LogWarning("Attempted to subscribe null listener on " + this.name);
+            return;
+        }
+        if (!listeners.Contains(listener))
+        {
+            listeners.Add(listener);
+        }
+    }
+
+    public void Unsubscribe(Action<T> listener)
+    {
+        if (listener == null)
+            return;
+        listeners.Remove(listener);
+    }
+
+    public void RaiseEvent(T data)
+    {
+        foreach (Action<T> listener in listeners)
+        {
+            listener?.Invoke(data);
+        }
+    }
+
+    public void ClearAllListeners()
+    {
+        listeners.Clear();
+    }
 }

--- a/Assets/Scripts/Events/EventChannel.cs
+++ b/Assets/Scripts/Events/EventChannel.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+using System;
+
+public class EventChannel<T> : ScriptableObject
+{
+    private event Action<T> OnEventRaised;
+
+    public void Subscribe(Action<T> listener) {}
+    public void Unsubscribe(Action<T> listener) {}
+    public void RaiseEvent(T data) {}
+    public void ClearAllListeners() {}
+}

--- a/Assets/Scripts/Events/EventChannel.cs.meta
+++ b/Assets/Scripts/Events/EventChannel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d00af224292cc40418f57da7d15b6c72

--- a/Assets/Scripts/Events/EventChannelTypes.cs
+++ b/Assets/Scripts/Events/EventChannelTypes.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Example EventChannel type that passes Strings as event parameters.
+/// </summary>
+[CreateAssetMenu(menuName = "Events/String Event Channel")]
+public class StringEventChannel : EventChannel<String> {}
+
+/// <summary>
+/// Example EventChannel type that passes `int` as event parameters.
+/// </summary>
+[CreateAssetMenu(menuName = "Events/Int Event Channel")]
+public class IntEventChannel : EventChannel<int> {}

--- a/Assets/Scripts/Events/EventChannelTypes.cs.meta
+++ b/Assets/Scripts/Events/EventChannelTypes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 00799906bba50f843b345373b613348b

--- a/Assets/Scripts/Events/readme.md
+++ b/Assets/Scripts/Events/readme.md
@@ -1,16 +1,83 @@
-Folder for Events scripts and files
+# Event Channel Documentation
 
-`EventChannel<T>` works as a generic blueprint for an event channel, where `T` is
-the type that is passed as an argument into the listener's method.
+## Overview
 
-Usage is as such:
+`EventChannel<T>` is a generic ScriptableObject-based event system that enables
+decoupled communication between components. The `T` parameter specifies the type
+of data passed to listeners when events are raised.
 
-To create a `EventChannel` asset, first you need a concrete definition of what kind
-of data that EventChannel will make use of. in `EventChannelTypes.cs`, there are 
-some example class definitions for what those look like. Each one also has an
-`[CreateAssetMenu]` tag that allows the `ScriptableObject` to be generated as an 
-asset. Once created as an asset, it can be dragged in like any other game object
-into a `[Serializable]` field supporting that type of Event.
+## Creating Event Channels
 
-Other examples of use for the base methods can be found in the 
-`EventChannelTests.cs` in the testing folder.
+### 1. Define a Concrete Type
+
+Event channels require concrete implementations to work with Unity's asset system.
+These are defined in `EventChannelTypes.cs`:
+
+```csharp
+[Create Asset Menu(menuName = "Events/Int Event Channel")]
+public class IntEventChannel : EventChannel<int> { }
+```
+### 2. Create an Asset
+
+Right-click in the Project window. Go to `Create/Events/[Your Event Type]`.
+
+### 3. Reference in Components
+
+```csharp
+public class ExampleComponent : Monobehaviour
+{
+    [SerializeField] private IntEventChannel scoreChangedChannel;
+    
+    private void OnEnable()
+    {
+        scoreChangedChannel.Subscribe(OnScoreChanged);
+    }
+    
+    private void OnDisable()
+    {
+        scoreChangedChannel.Unsubscribe(OnScoreChanged);
+    }
+    
+    private void OnScoreChanged(int newScore)
+    {
+        Debug.Log($"Score changed to: {newScore}");
+}
+```
+
+## API Reference
+
+### Methods
+
+- `Subscribe<Action<T> listener)` : Registers a listener. Prevents duplicate
+  subscriptions. `Action<T>` is a method name to be triggered.
+- `Unsubscribe<Action<T> listener)` : Removes a listener.
+- `RaiseEvent(T data)` : Invokes all subscribed listeners method with the 
+  supplied data.
+- `ClearAllListeners()` : Removes all listeners (useful for cleanup)
+
+### Null Safety
+
+- Attempting to subscribe a `null` listener will log a warning and be ignored.
+- The `?.Invoke()` pattern ensures that listeners are safely invoked, even 
+  if `null`.
+
+### Examples
+
+See `EventChannelTests.cs` for unit test examples demonstrating all core
+functionality.
+
+## Best Practices
+
+- Always unsubscribe in `OnDisable()` or `OnDestroy()` to prevent memory leaks
+- Use `[SerializeField]` to expose channels in the Inspector for easy wiring
+- Create specfic event channels for different game events (`PlayerMovedChannel`,
+  `TurnStartedChannel`, etc.)
+- Name your channel assets descriptively ("PlayerMovedChannel", not "Event1")
+
+### Why Use This?
+
+- Loose coupling: Components don't need references to each other.
+- Reusability: Same channel can be used by multiple systems.
+- Debuggability: Channel assets are visible in teh project and can be inspected
+  at runtime.
+- Testability: Easy to create channel instances in unit tests.

--- a/Assets/Scripts/Events/readme.md
+++ b/Assets/Scripts/Events/readme.md
@@ -1,1 +1,16 @@
 Folder for Events scripts and files
+
+`EventChannel<T>` works as a generic blueprint for an event channel, where `T` is
+the type that is passed as an argument into the listener's method.
+
+Usage is as such:
+
+To create a `EventChannel` asset, first you need a concrete definition of what kind
+of data that EventChannel will make use of. in `EventChannelTypes.cs`, there are 
+some example class definitions for what those look like. Each one also has an
+`[CreateAssetMenu]` tag that allows the `ScriptableObject` to be generated as an 
+asset. Once created as an asset, it can be dragged in like any other game object
+into a `[Serializable]` field supporting that type of Event.
+
+Other examples of use for the base methods can be found in the 
+`EventChannelTests.cs` in the testing folder.

--- a/Assets/Scripts/GameScripts.asmdef
+++ b/Assets/Scripts/GameScripts.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "GameScripts"
+}

--- a/Assets/Scripts/GameScripts.asmdef.meta
+++ b/Assets/Scripts/GameScripts.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d1952b55e62263949bcae05f5f255910
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/EventChannelTests.cs
+++ b/Assets/Tests/EditMode/EventChannelTests.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests.EditMode
+{
+    public class EventChannelTests
+    {
+        private EventChannel<int> channel;
+        private int callbackCount;
+        private int lastReceivedValue;
+
+        [SetUp]
+        public void SetUp()
+        {
+            channel = ScriptableObject.CreateInstance<IntEventChannel>();
+            callbackCount = 0;
+            lastReceivedValue = 0;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(channel);
+        }
+
+        [Test]
+        public void Subscribe_AddsListener()
+        {
+            void Listener(int value) => callbackCount++;
+
+            channel.Subscribe(Listener);
+            channel.Subscribe(Listener);
+            channel.RaiseEvent(5);
+            
+            Assert.AreEqual(1, callbackCount, "Listener should only be called once.");
+        }
+
+        [Test]
+        public void Unsubscribe_RemovesListener()
+        {
+            void Listener(int value) => callbackCount++;
+            channel.Subscribe(Listener);
+
+            channel.Unsubscribe(Listener);
+            channel.RaiseEvent(5);
+            
+            Assert.AreEqual(0, callbackCount);
+        }
+
+        [Test]
+        public void RaiseEvent_PassesCorrectData()
+        {
+            void Listener(int value) => lastReceivedValue = value;
+            channel.Subscribe(Listener);
+            
+            channel.RaiseEvent(42);
+            
+            Assert.AreEqual(42, lastReceivedValue);
+        }
+
+        [Test]
+        public void Subscribe_WithNullListener_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => channel.Subscribe(null));
+        }
+
+        [Test]
+        public void ClearAllListeners_RemovesAllListeners()
+        {
+            void Listener1(int value) => callbackCount++;
+            void Listener2(int value) => callbackCount++;
+            channel.Subscribe(Listener1);
+            channel.Subscribe(Listener2);
+
+            channel.ClearAllListeners();
+            channel.RaiseEvent(5);
+            
+            Assert.AreEqual(0, callbackCount);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/EventChannelTests.cs.meta
+++ b/Assets/Tests/EditMode/EventChannelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: effd73239f3aded4fbed00da9669a83d

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -1,9 +1,24 @@
 {
     "name": "Tests",
-    "optionalUnityReferences": [
-        "TestAssemblies"
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "GameScripts"
     ],
     "includePlatforms": [
         "Editor"
-    ]
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
As a developer, I want to create ScriptableObject-based event channels, so that components can communicate without tight coupling.

This adds the `EventChannel<T>` abstract `ScriptableObject`, and provides a file for creating concrete definitions of that channel with specific data types.

Also added is a suite of tests for checking the functionality of the `EventChannel<T>` interface, and comprehensive documentation on use.