### PR TITLE
US14: As a developer, I want a PlayerManager to coordinate all players, so that player operations are centralized.

### DIFF
--- a/Assets/Scripts/Board/CodeReview.md.meta
+++ b/Assets/Scripts/Board/CodeReview.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64b82e4882abadb42998bd5def625603
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Managers/PlayerManager.cs
@@ -61,4 +61,18 @@ public class PlayerManager : MonoBehaviour
             return null;
         }
     }
+
+    /// <summary>
+    /// Returns a List of all Player ScriptableObjects.
+    /// </summary>
+    /// <returns>List of all Player ScriptableObjects</returns>
+    public List<Player> GetAllPlayers()
+    {
+        var playersCopy = new List<Player>();
+        
+        foreach (var player in players)
+            playersCopy.Add(player);
+        
+        return playersCopy;
+    }
 }

--- a/Assets/Scripts/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Managers/PlayerManager.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerManager : MonoBehaviour
+{
+    private List<Player> players = new List<Player>();
+    
+    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    /// <summary>
+    /// Initializes given number of Players. For now, just assigns "Player X" to the
+    /// name, where X is the player number. Eventually, should be enhanced to allow
+    /// for assigning names and/or colors.
+    /// </summary>
+    /// <param name="numPlayers">Number of players to initialize</param>
+    public void InitializePlayers(int numPlayers)
+    {
+        for (int i = 0; i < numPlayers; i++)
+        {
+            // I think making the Player a scriptable object is the wrong move,
+            // since its meant to be a data class, not an Asset in the browser.
+            // We might rethink this later, if we create a list of specific
+            // "Player" archetypes to get around naming issues, like Monopoly's
+            // pieces. In that case, we should probably do something totally
+            // different for creating players.
+            Player newPlayer = ScriptableObject.CreateInstance<Player>();
+            
+            newPlayer.SetId(i);
+            // doing i+1 so that the name is Player 1, 2, 3, etc.
+            newPlayer.SetPName($"Player {i+1}");
+            // setting money should be done somewhere else, I think...
+            
+            players.Add(newPlayer);
+        }
+    }
+
+    /// <summary>
+    /// Gets a Player object by ID.
+    /// </summary>
+    /// <param name="playerId">ID of the player to get.</param>
+    /// <returns>Player ScriptableObject, or null if ID not found.</returns>
+    public Player GetPlayer(int playerId)
+    {
+        if (players != null && playerId >= 0 && playerId < players.Count)
+            return players[playerId];
+        else
+        {
+            Debug.LogError("PlayerManager: GetPlayer " +
+                           "attempted access of playerID out" +
+                           $"of bounds: {playerId}");
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/Managers/PlayerManager.cs.meta
+++ b/Assets/Scripts/Managers/PlayerManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93e73d5229aa3a7429dda88fa656ad99

--- a/Assets/Tests/EditMode/PlayerManagerTests.cs
+++ b/Assets/Tests/EditMode/PlayerManagerTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor.VersionControl;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests.EditMode
+{
+    public class PlayerManagerTests
+    {
+        private GameObject gameObject;
+        private PlayerManager playerManager;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            gameObject = new GameObject();
+            playerManager = gameObject.AddComponent<PlayerManager>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(gameObject);
+        }
+
+        [Test]
+        public void PlayerManager_CanInitialize2Players()
+        {
+            playerManager.InitializePlayers(2);
+
+            List<Player> players = playerManager.GetAllPlayers();
+            
+            Assert.AreEqual(2, players.Count);
+            Assert.AreEqual("Player 1", players[0].GetPName());
+            Assert.AreEqual("Player 2", players[1].GetPName());
+        }
+        
+        [Test]
+        public void PlayerManager_CanInitialize3Players()
+        {
+            playerManager.InitializePlayers(3);
+
+            List<Player> players = playerManager.GetAllPlayers();
+            
+            Assert.AreEqual(3, players.Count);
+            Assert.AreEqual("Player 1", players[0].GetPName());
+            Assert.AreEqual("Player 2", players[1].GetPName());
+            Assert.AreEqual("Player 3", players[2].GetPName());
+        }
+        
+        [Test]
+        public void PlayerManager_CanInitialize4Players()
+        {
+            playerManager.InitializePlayers(4);
+
+            List<Player> players = playerManager.GetAllPlayers();
+            
+            Assert.AreEqual(4, players.Count);
+            Assert.AreEqual("Player 1", players[0].GetPName());
+            Assert.AreEqual("Player 2", players[1].GetPName());
+            Assert.AreEqual("Player 3", players[2].GetPName());
+            Assert.AreEqual("Player 4", players[3].GetPName());
+        }
+
+        [Test]
+        public void PlayerManager_CanGetPlayerById()
+        {
+            playerManager.InitializePlayers(4);
+
+            Player player = playerManager.GetPlayer(2);
+            
+            Assert.AreEqual(2, player.GetId());
+            Assert.AreEqual("Player 3", player.GetPName());
+        }
+
+        [Test]
+        public void PlayerManager_GetByInvalidIdReturnsNull()
+        {
+            playerManager.InitializePlayers(2);
+            
+            LogAssert.Expect("PlayerManager: GetPlayer " +
+                             "attempted access of playerID out" +
+                             "of bounds: 3");
+            Assert.IsNull(playerManager.GetPlayer(3));
+        }
+    }
+}
+

--- a/Assets/Tests/EditMode/PlayerManagerTests.cs.meta
+++ b/Assets/Tests/EditMode/PlayerManagerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90ab65d2142417448976ece33da42fa0


### PR DESCRIPTION
Adds PlayerManager MonoBehaviour to manage Player data.
Has methods for accessing players, and initializing them.

Includes tests on all methods.

Some notes: we might want to review if Player should be a ScriptableObject or not. Right now, being one adds some overhead to how we use them in code that might become a problem later. However, if we decide to create player "archetypes" where a player type corresponds to a name, piece, and color, then being SOs actually makes a lot of sense. Having a selectable list of Player archetypes would actually be a nice solution to the requirement that we shouldn't allow people to write in whatever they want as a name- players have predetermined "names" or "characters". Kind of like the Shoe or Thimble in classic Monopoly.

Something to consider.