### PR TITLE
Merge US-103-hotfix into dev

### DIFF
--- a/Assets/Tests/EditMode/EventCommunicationTests.cs
+++ b/Assets/Tests/EditMode/EventCommunicationTests.cs
@@ -30,6 +30,13 @@ namespace PsycheOpoly.Tests
             gameManager.playerManager = playerManager;
             gameManager.turnStartedChannel = turnStartedChannel;
 
+            //null ref exceptions were caused originally in this test because the test envrment 
+            //wasn't recognizing these objects so i just created mocks essentially for objects where
+            //null ref exceptions were occurring -- US-103-hotfix
+            gameManager.gameStateChangeChannel = ScriptableObject.CreateInstance<GameStateEventChannel>();
+            playerManager.playerAddedEventChannel = ScriptableObject.CreateInstance<PlayerEventChannel>();
+            playerManager.playerRemovedEventChannel = ScriptableObject.CreateInstance<PlayerEventChannel>();
+
             boardManager.InitializeBoard(10);
         }
 


### PR DESCRIPTION
GameManager.cs was hitting NullReferenceExceptions when running EventCommunicationTests.cs. Primarily, the event channel variables; created mocks to be able to run in testing, and corrected the issue. All tests are up to date and running as expected. 