### PR TITLE
Merge hotfix into dev

### DIFF
--- a/Assets/Scripts/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Managers/PlayerManager.cs
@@ -71,6 +71,12 @@ public class PlayerManager : MonoBehaviour
             
             players.Add(newPlayer);
 
+            //notify event channel listeners of added player 
+            if (playerAddedEventChannel != null)
+            {
+                playerAddedEventChannel.RaiseEvent(newPlayer);
+            }
+
             //Log confirmation
             Debug.Log($"Initialized {newPlayer.GetPName()} with ${newPlayer.GetMoney()}.");
         }


### PR DESCRIPTION
Recognized a problem with the InitializePlayer method in PlayerManager.cs was not firing the proper event channel listener; added the fix to ensure the InitializePlayers_Raises_OnPlayerAdded_ForEach_NewPlayer test case was running properly. 