### PR TITLE
US 254 To Create Basic Rent Logic

### DIFF
--- a/Assets/Scripts/Managers/Rent.meta
+++ b/Assets/Scripts/Managers/Rent.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 644623bca2e3eca479384552bd4d1846
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/Rent/IRentStrategy.cs
+++ b/Assets/Scripts/Managers/Rent/IRentStrategy.cs
@@ -1,0 +1,8 @@
+namespace Assets.Scripts.Managers.Rent
+{
+    public interface IRentStrategy
+    {
+        /// <summary>Returns rent due for landing.</summary>
+        int ComputeRent(ITileRentInfo tile, Player owner, int diceTotal, IOwnershipService own, IRuleSet rules);
+    }
+}

--- a/Assets/Scripts/Managers/Rent/IRentStrategy.cs.meta
+++ b/Assets/Scripts/Managers/Rent/IRentStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a342496ac9404f14c90705e3c1d24325

--- a/Assets/Scripts/Managers/Rent/OwnershipServiceAdapter.cs
+++ b/Assets/Scripts/Managers/Rent/OwnershipServiceAdapter.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Assets.Scripts.Managers.Rent
+{
+    //Replace later with real ownership source
+    public class OwnershipServiceAdapter : MonoBehaviour, IOwnershipService
+    {
+        private readonly Dictionary<ITileRentInfo, Player> owners = new();
+        private readonly Dictionary<Player, HashSet<ITileRentInfo>> ownedByPlayer = new();
+
+        //public API
+        public void SetOwner(ITileRentInfo tile, Player owner)
+        {
+            owners[tile] = owner;
+
+            if (!ownedByPlayer.TryGetValue(owner, out var set))
+            {
+                set = new HashSet<ITileRentInfo>();
+                ownedByPlayer[owner] = set;
+            }
+            set.Add(tile);
+        }
+
+        //IOwnershipService
+        public Player GetOwner(ITileRentInfo tile)
+        {
+            owners.TryGetValue(tile, out var p);
+            return p;
+        }
+
+        public int CountOwnedInGroup(Player owner, ColorGroup group)
+        {
+            if (owner == null) return 0;
+            if (!ownedByPlayer.TryGetValue(owner, out var set)) return 0;
+
+            int c = 0;
+            foreach (var t in set)
+                if (t.Type == TileType.Street && t.Group == group) c++;
+            return c;
+        }
+
+        public int CountRailroadsOwned(Player owner)
+        {
+            if (owner == null) return 0;
+            if (!ownedByPlayer.TryGetValue(owner, out var set)) return 0;
+
+            int c = 0;
+            foreach (var t in set)
+                if (t.Type == TileType.Railroad) c++;
+            return c;
+        }
+
+        public bool OwnsBothUtilities(Player owner)
+        {
+            return CountUtilities(owner) >= 2;
+        }
+
+        //helper
+        private int CountUtilities(Player owner)
+        {
+            if (owner == null) return 0;
+            if (!ownedByPlayer.TryGetValue(owner, out var set)) return 0;
+
+            int c = 0;
+            foreach (var t in set)
+                if (t.Type == TileType.Utility) c++;
+            return c;
+        }
+    }
+}

--- a/Assets/Scripts/Managers/Rent/OwnershipServiceAdapter.cs.meta
+++ b/Assets/Scripts/Managers/Rent/OwnershipServiceAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fb615b7991d0d764ba31a6ab73e382ff

--- a/Assets/Scripts/Managers/Rent/Primitives.cs
+++ b/Assets/Scripts/Managers/Rent/Primitives.cs
@@ -1,0 +1,36 @@
+namespace Assets.Scripts.Managers.Rent
+{
+    public enum TileType { Street, Railroad, Utility, Other }
+    public enum ColorGroup { None, Brown, LightBlue, Pink, Orange, Red, Yellow, Green, DarkBlue }
+
+    /// <summary>Minimal shape strategy needs. 
+    /// Create adapters to connect real tile data.</summary>
+    public interface ITileRentInfo
+    {
+        string Name { get; }
+        TileType Type { get; }
+        ColorGroup Group { get; }     //Street group
+        bool IsMortgaged { get; }
+        int HouseCount { get; }       
+        int BaseRent { get; }         //street base rent
+        int[] RentByHouses { get; }   
+    }
+
+    /// <summary>Rules/constants centralized to keep StandardRentStrategy clean.</summary>
+    public interface IRuleSet
+    {
+        int RailroadBaseRent();       //usually 25 in game
+        int UtilityRentSingleMult();  //usually 4 in game
+        int UtilityRentBothMult();    //usually 10 in game
+        int StreetsInGroup(ColorGroup g); //total street amount in a color set
+    }
+
+    /// <summary>Ownership lookups kept external to Strategy.</summary>
+    public interface IOwnershipService
+    {
+        Player GetOwner(ITileRentInfo tile);
+        int CountOwnedInGroup(Player owner, ColorGroup group);
+        int CountRailroadsOwned(Player owner);
+        bool OwnsBothUtilities(Player owner);
+    }
+}

--- a/Assets/Scripts/Managers/Rent/Primitives.cs.meta
+++ b/Assets/Scripts/Managers/Rent/Primitives.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da95489100c6d30419a0ecd3c1b56f98

--- a/Assets/Scripts/Managers/Rent/RentManager.cs
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+using Logging; 
+
+namespace Assets.Scripts.Managers.Rent
+{
+    ///Gets tile and owner then asks strategy for rent 
+    ///then moves money.  Also subscribes to landing trigger 
+    public class RentManager : MonoBehaviour
+    {
+        [Header("Dependencies")]
+        [SerializeField] private PlayerManager PlayerManager;
+        [SerializeField] private EconomyAdapter economy; //money mover for now
+        [SerializeField] private OwnershipServiceAdapter ownership;
+        [SerializeField] private RuleSet rules = new();
+
+        private IRentStrategy strategy = new StandardRentStrategy();
+
+        ///Compute and transfer rent for a landing. 
+        ///tenant - player who landed
+        ///tile - tile info adapter for strategy
+        ///diceTotal - needed for utilities 
+        public void TryChargeRent(Player tenant, ITileRentInfo tile, int diceTotal)
+        {
+            if (tenant == null || tile == null) return;
+
+            var owner = ownership.GetOwner(tile);
+            if(owner == null || owner == tenant) return;
+
+            int rent = strategy.ComputeRent(tile, owner, diceTotal, ownership, rules);
+            if (rent <= 0) return; 
+
+            bool ok = economy.Transfer(tenant, owner, rent);
+        }
+    }
+
+    //Placeholder until final version of economy adapter is created
+    public class EconomyAdapter : MonoBehaviour
+    {
+        public bool Transfer(Player from, Player to, int amount)
+        {
+            if (amount <= 0) return true;
+            int have = from.GetMoney();
+            if (have < amount) amount = have; //Trigger Bankruptcy here
+            from.SetMoney(have - amount);
+            to.SetMoney(to.GetMoney() + amount);
+            return true; 
+        }
+    }
+
+    //Rule constants 
+    [System.Serializable]
+    public class RuleSet : IRuleSet{
+        public int RailroadBase = 25;
+        public int UtilitySingle = 4;
+        public int UtilityBoth = 10;
+
+        public int RailroadBaseRent() => RailroadBase;
+        public int UtilityRentSingleMult() => UtilitySingle;
+        public int UtilityRentBothMult() => UtilityBoth;
+
+        //Default Monopoly set sizes
+        public int StreetsInGroup(ColorGroup g) =>
+            g switch
+            {
+                ColorGroup.Brown or ColorGroup.DarkBlue => 2,
+                ColorGroup.LightBlue or ColorGroup.Pink or ColorGroup.Orange or ColorGroup.Red or ColorGroup.Yellow or ColorGroup.Green => 3,
+                _ => 0
+            };
+    }
+
+}

--- a/Assets/Scripts/Managers/Rent/RentManager.cs
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs
@@ -1,57 +1,89 @@
 using UnityEngine;
-using Logging; 
 
 namespace Assets.Scripts.Managers.Rent
 {
-    ///Gets tile and owner then asks strategy for rent 
-    ///then moves money.  Also subscribes to landing trigger 
+    ///Gets tile and owner, asks the strategy for the rent, and moves money.
+    ///Self-wires Economy/Ownership/Rules in Awake() 
+    ///so it works in EditMode tests where Awake() may not fire.
     public class RentManager : MonoBehaviour
     {
         [Header("Dependencies")]
-        [SerializeField] private PlayerManager PlayerManager;
-        [SerializeField] private EconomyAdapter economy; //money mover for now
-        [SerializeField] private OwnershipServiceAdapter ownership;
-        [SerializeField] private RuleSet rules = new();
+        [SerializeField] private PlayerManager playerManager;                //not used by rent calc yet
+        [SerializeField] private EconomyAdapter economy;                     //money mover (placeholder)
+        [SerializeField] private OwnershipServiceAdapter ownership;          //ownership source of truth (adapter)
+        [SerializeField] private RuleSet rules = new RuleSet();              //rule constants
 
         private IRentStrategy strategy = new StandardRentStrategy();
 
-        ///Compute and transfer rent for a landing. 
-        ///tenant - player who landed
-        ///tile - tile info adapter for strategy
-        ///diceTotal - needed for utilities 
+        private void Awake()
+        {
+            EnsureDependencies();
+        }
+
+        //Compute and transfer rent when a tenant lands on a tile.
+        //tentant - The landing player
+        //tile - Tile adapter exposing rent-relevant data
+        //dicetotal - Needed for utilities
         public void TryChargeRent(Player tenant, ITileRentInfo tile, int diceTotal)
         {
             if (tenant == null || tile == null) return;
 
+            EnsureDependencies();
+
             var owner = ownership.GetOwner(tile);
-            if(owner == null || owner == tenant) return;
+            if (owner == null || owner == tenant) return;
 
             int rent = strategy.ComputeRent(tile, owner, diceTotal, ownership, rules);
-            if (rent <= 0) return; 
+            if (rent <= 0) return;
 
             bool ok = economy.Transfer(tenant, owner, rent);
         }
+
+        //Make sure serialized dependencies are not null
+        private void EnsureDependencies()
+        {
+            if (!economy)
+                economy = GetComponent<EconomyAdapter>() ?? gameObject.AddComponent<EconomyAdapter>();
+
+            if (!ownership)
+                ownership = GetComponent<OwnershipServiceAdapter>() ?? gameObject.AddComponent<OwnershipServiceAdapter>();
+
+            if (rules == null)
+                rules = new RuleSet();
+        }
     }
 
-    //Placeholder until final version of economy adapter is created
+    //Money mover. Replace with your real EconomyManager later.
     public class EconomyAdapter : MonoBehaviour
     {
         public bool Transfer(Player from, Player to, int amount)
         {
             if (amount <= 0) return true;
+
             int have = from.GetMoney();
-            if (have < amount) amount = have; //Trigger Bankruptcy here
+            if (have < amount)
+            {
+                //placeholder trigger bankruptcy flow, for now pay what you can
+                amount = have;
+            }
+
             from.SetMoney(have - amount);
             to.SetMoney(to.GetMoney() + amount);
-            return true; 
+            return true;
         }
     }
 
-    //Rule constants 
+    //Rule constants for standard Monopoly rent. can be converted to ScriptableObject
     [System.Serializable]
-    public class RuleSet : IRuleSet{
+    public class RuleSet : IRuleSet
+    {
+        [Tooltip("Base rent for 1 owned railroad (25, 50, 100, 200 scaling).")]
         public int RailroadBase = 25;
+
+        [Tooltip("Utility multiplier when owner has a single utility.")]
         public int UtilitySingle = 4;
+
+        [Tooltip("Utility multiplier when owner has both utilities.")]
         public int UtilityBoth = 10;
 
         public int RailroadBaseRent() => RailroadBase;
@@ -67,5 +99,4 @@ namespace Assets.Scripts.Managers.Rent
                 _ => 0
             };
     }
-
 }

--- a/Assets/Scripts/Managers/Rent/RentManager.cs.meta
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ccd3f32730a5704892a611a7645db3f

--- a/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
+++ b/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
@@ -29,6 +29,7 @@ namespace Assets.Scripts.Managers.Rent
             int houses = Mathf.Clamp(tile.HouseCount, 0, tile.RentByHouses?.Length > 0 ? tile.RentByHouses.Length - 1 : 0);
 
             //Houses and hotels table if needed will be checked first
+            //Completes task 283
             if (houses > 0 && tile.RentByHouses != null && tile.RentByHouses.Length > houses)
             {
                 return tile.RentByHouses[houses];

--- a/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
+++ b/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
@@ -1,0 +1,66 @@
+using System;
+using UnityEngine;
+
+namespace Assets.Scripts.Managers.Rent
+{
+    /// <summary>Monopoly stype rent computation. </summary>
+    public class StandardRentStrategy : IRentStrategy
+    {
+        public int ComputeRent(ITileRentInfo tile, Player owner, int diceTotal, IOwnershipService own, IRuleSet rules)
+        {
+            if (tile == null || owner == null) return 0;
+            if (tile.IsMortgaged) return 0;
+
+            switch (tile.Type)
+            {
+                case TileType.Street:
+                    return StreetRent(tile, owner, own, rules);
+                case TileType.Railroad:
+                    return RailroadRent(owner, own, rules);
+                case TileType.Utility: 
+                    return UtilityRent(owner, diceTotal, own, rules);
+                default: 
+                    return 0; 
+            }
+        }
+
+        private int StreetRent(ITileRentInfo tile, Player owner, IOwnershipService own, IRuleSet rules)
+        {
+            int houses = Mathf.Clamp(tile.HouseCount, 0, tile.RentByHouses?.Length > 0 ? tile.RentByHouses.Length - 1 : 0);
+
+            //Houses and hotels table if needed will be checked first
+            if (houses > 0 && tile.RentByHouses != null && tile.RentByHouses.Length > houses)
+            {
+                return tile.RentByHouses[houses];
+            }
+
+            //If there are no houses check monoploy which doubles base rent
+            bool hasMonopoly = own.CountOwnedInGroup(owner, tile.Group) >= rules.StreetsInGroup(tile.Group);
+            return hasMonopoly ? tile.BaseRent * 2 : tile.BaseRent;
+        }
+
+        private int RailroadRent(Player owner, IOwnershipService own, IRuleSet rules)
+        {
+            int n = Mathf.Clamp(own.CountRailroadsOwned(owner), 0, 4);
+            if (n <= 0) return 0;
+
+            //Doubles based on how many owned
+            int baseRent = rules.RailroadBaseRent();
+            int rent = baseRent << (n - 1);
+            return rent;
+        }
+
+        private int UtilityRent(Player owner, int diceTotal, IOwnershipService own, IRuleSet rules)
+        {
+            if (diceTotal < 0) diceTotal = 0;
+            bool ownsBoth = own.OwnsBothUtilities(owner);
+            int mult = ownsBoth ? rules.UtilityRentBothMult() : rules.UtilityRentSingleMult();
+            return diceTotal * mult; 
+        }
+
+    }
+
+
+
+
+}

--- a/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs.meta
+++ b/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bfdb9ecf848e8f14b9f28f10f7e438d4

--- a/Assets/Tests/EditMode/RentTests.meta
+++ b/Assets/Tests/EditMode/RentTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8112fbc41925344fa3962c0a75e4086
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/RentTests/RentManagerIntegrationTests.cs
+++ b/Assets/Tests/EditMode/RentTests/RentManagerIntegrationTests.cs
@@ -1,0 +1,145 @@
+using NUnit.Framework;
+using Assets.Scripts.Managers.Rent;
+using UnityEngine;
+
+namespace Tests.EditMode.RentTests
+{
+    ///Verifies RentManager actually moves money using the strategy and adapters.
+    public class RentManagerIntegrationTests : RentTestBase
+    {
+        [Test]
+        public void Charges_BaseRent_ToOwner()
+        {
+            //Given a street with base 10 no monopoly and no houses
+            var prop = Street("Prop A", ColorGroup.Red, baseRent: 10, houses: 0, mortgaged: false);
+            ownership.SetOwner(prop, owner);
+
+            int beforeTenant = tenant.GetMoney();
+            int beforeOwner  = owner.GetMoney();
+
+            rentManager.TryChargeRent(tenant, prop, diceTotal: 7); //dice ignored for streets
+
+            Assert.AreEqual(beforeTenant - 10, tenant.GetMoney());
+            Assert.AreEqual(beforeOwner  + 10, owner.GetMoney());
+        }
+
+        [Test]
+        public void Monopoly_Doubles_Base()
+        {
+            var a = Street("A", ColorGroup.Orange, 10);
+            var b = Street("B", ColorGroup.Orange, 10);
+            var c = Street("C", ColorGroup.Orange, 10);
+
+            ownership.SetOwner(a, owner);
+            ownership.SetOwner(b, owner);
+            ownership.SetOwner(c, owner);
+
+            int beforeTenant = tenant.GetMoney();
+            int beforeOwner  = owner.GetMoney();
+
+            rentManager.TryChargeRent(tenant, a, diceTotal: 0);
+
+            Assert.AreEqual(beforeTenant - 20, tenant.GetMoney()); //doubled base
+            Assert.AreEqual(beforeOwner  + 20, owner.GetMoney());
+        }
+
+        [Test]
+        public void Houses_Use_Table()
+        {
+            var table = new[] { 8, 40, 100, 300, 450, 600 };
+            var prop  = Street("Housey", ColorGroup.Yellow, baseRent: 8, houses: 3, mortgaged: false, rentTable: table);
+            ownership.SetOwner(prop, owner);
+
+            int beforeTenant = tenant.GetMoney();
+            int beforeOwner  = owner.GetMoney();
+
+            rentManager.TryChargeRent(tenant, prop, 0);
+
+            Assert.AreEqual(beforeTenant - 300, tenant.GetMoney());
+            Assert.AreEqual(beforeOwner  + 300, owner.GetMoney());
+        }
+
+        [Test]
+        public void Railroad_Scales_Properly()
+        {
+            var rr1 = Railroad("RR1");
+            var rr2 = Railroad("RR2");
+            var rr3 = Railroad("RR3");
+            var rr4 = Railroad("RR4");
+
+            ownership.SetOwner(rr1, owner);
+
+            int t0 = tenant.GetMoney();
+            int o0 = owner.GetMoney();
+            rentManager.TryChargeRent(tenant, rr1, 0);
+            Assert.AreEqual(t0 - 25, tenant.GetMoney());
+            Assert.AreEqual(o0 + 25, owner.GetMoney());
+
+            ownership.SetOwner(rr2, owner);
+            int t1 = tenant.GetMoney();
+            int o1 = owner.GetMoney();
+            rentManager.TryChargeRent(tenant, rr1, 0);
+            Assert.AreEqual(t1 - 50, tenant.GetMoney());
+            Assert.AreEqual(o1 + 50, owner.GetMoney());
+
+            ownership.SetOwner(rr3, owner);
+            int t2 = tenant.GetMoney();
+            int o2 = owner.GetMoney();
+            rentManager.TryChargeRent(tenant, rr1, 0);
+            Assert.AreEqual(t2 - 100, tenant.GetMoney());
+            Assert.AreEqual(o2 + 100, owner.GetMoney());
+
+            ownership.SetOwner(rr4, owner);
+            int t3 = tenant.GetMoney();
+            int o3 = owner.GetMoney();
+            rentManager.TryChargeRent(tenant, rr1, 0);
+            Assert.AreEqual(t3 - 200, tenant.GetMoney());
+            Assert.AreEqual(o3 + 200, owner.GetMoney());
+        }
+
+        [Test]
+        public void Utilities_Use_Dice_4x_and_10x()
+        {
+            var u1 = Utility("Electric");
+            var u2 = Utility("Water");
+            ownership.SetOwner(u1, owner);
+
+            int bt = tenant.GetMoney();
+            int bo = owner.GetMoney();
+            rentManager.TryChargeRent(tenant, u1, 7); //7*4
+            Assert.AreEqual(bt - 28, tenant.GetMoney());
+            Assert.AreEqual(bo + 28, owner.GetMoney());
+
+            ownership.SetOwner(u2, owner);
+            bt = tenant.GetMoney(); bo = owner.GetMoney();
+            rentManager.TryChargeRent(tenant, u1, 7); //owns both
+            Assert.AreEqual(bt - 70, tenant.GetMoney());
+            Assert.AreEqual(bo + 70, owner.GetMoney());
+        }
+
+        [Test]
+        public void Mortgaged_Is_Zero()
+        {
+            var prop = Street("Mort", ColorGroup.Red, baseRent: 20, houses: 0, mortgaged: true);
+            ownership.SetOwner(prop, owner);
+
+            int bt = tenant.GetMoney();
+            int bo = owner.GetMoney();
+            rentManager.TryChargeRent(tenant, prop, 0);
+
+            Assert.AreEqual(bt, tenant.GetMoney());
+            Assert.AreEqual(bo, owner.GetMoney());
+        }
+
+        [Test]
+        public void SelfOwned_NoCharge()
+        {
+            var prop = Street("Self", ColorGroup.Green, baseRent: 30);
+            ownership.SetOwner(prop, tenant); //tenant owns it
+
+            int bt = tenant.GetMoney();
+            rentManager.TryChargeRent(tenant, prop, 0);
+            Assert.AreEqual(bt, tenant.GetMoney());
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RentTests/RentManagerIntegrationTests.cs.meta
+++ b/Assets/Tests/EditMode/RentTests/RentManagerIntegrationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 276ee46eeddea1f42b085197b9c94548

--- a/Assets/Tests/EditMode/RentTests/RentTestBase.cs
+++ b/Assets/Tests/EditMode/RentTests/RentTestBase.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+using UnityEngine;
+using Tests.EditMode; // adjust if your ManagerTestBase namespace differs
+using Assets.Scripts.Managers.Rent;
+
+namespace Tests.EditMode.RentTests
+{
+    public class RentTestBase : ManagerTestBase
+    {
+        protected GameObject rentGO;
+        protected RentManager rentManager;
+        protected EconomyAdapter economy;
+        protected OwnershipServiceAdapter ownership;
+
+        protected Player owner;
+        protected Player tenant;
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            owner  = ScriptableObject.CreateInstance<Player>();
+            owner.SetPName("Owner");
+            owner.SetMoney(10_000);
+
+            tenant = ScriptableObject.CreateInstance<Player>();
+            tenant.SetPName("Tenant");
+            tenant.SetMoney(10_000);
+
+            rentGO      = new GameObject("RentManager");
+            rentManager = rentGO.AddComponent<RentManager>();
+
+            economy     = rentGO.AddComponent<EconomyAdapter>();
+            ownership   = rentGO.AddComponent<OwnershipServiceAdapter>();
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            DestroyTestObjects(rentGO);
+            Object.DestroyImmediate(owner);
+            Object.DestroyImmediate(tenant);
+        }
+
+        protected ITileRentInfo Street(
+            string name, ColorGroup group, int baseRent, int houses = 0, bool mortgaged = false,
+            int[] rentTable = null)
+        {
+            return new FakeTile
+            {
+                Name = name,
+                Type = TileType.Street,
+                Group = group,
+                BaseRent = baseRent,
+                HouseCount = houses,
+                IsMortgaged = mortgaged,
+                RentByHouses = rentTable ?? new[] { baseRent, baseRent * 5, baseRent * 15, baseRent * 37, baseRent * 46, baseRent * 55 }
+            };
+        }
+
+        protected ITileRentInfo Railroad(string name = "RR") => new FakeTile
+        {
+            Name = name, Type = TileType.Railroad, Group = ColorGroup.None, BaseRent = 0,
+            HouseCount = 0, IsMortgaged = false, RentByHouses = new int[0]
+        };
+
+        protected ITileRentInfo Utility(string name) => new FakeTile
+        {
+            Name = name, Type = TileType.Utility, Group = ColorGroup.None, BaseRent = 0,
+            HouseCount = 0, IsMortgaged = false, RentByHouses = new int[0]
+        };
+
+        private class FakeTile : ITileRentInfo
+        {
+            public string Name { get; set; }
+            public TileType Type { get; set; }
+            public ColorGroup Group { get; set; }
+            public bool IsMortgaged { get; set; }
+            public int HouseCount { get; set; }
+            public int BaseRent { get; set; }
+            public int[] RentByHouses { get; set; }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RentTests/RentTestBase.cs.meta
+++ b/Assets/Tests/EditMode/RentTests/RentTestBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b999dd78a22fbb342aac50f917099b36

--- a/Assets/Tests/EditMode/RentTests/StandardRentStrategyTests.cs
+++ b/Assets/Tests/EditMode/RentTests/StandardRentStrategyTests.cs
@@ -1,0 +1,188 @@
+using NUnit.Framework;
+using UnityEngine;
+using Assets.Scripts.Managers.Rent;
+
+namespace Tests.EditMode.RentTests
+{
+    public class StandardRentStrategyTests
+    {
+        private class Tile : ITileRentInfo
+        {
+            public string Name { get; set; }
+            public TileType Type { get; set; }
+            public ColorGroup Group { get; set; }
+            public bool IsMortgaged { get; set; }
+            public int HouseCount { get; set; }
+            public int BaseRent { get; set; }
+            public int[] RentByHouses { get; set; }
+        }
+
+        private class Rules : IRuleSet
+        {
+            public int RailroadBaseRent() => 25;
+            public int UtilityRentSingleMult() => 4;
+            public int UtilityRentBothMult() => 10;
+            public int StreetsInGroup(ColorGroup g) =>
+                (g == ColorGroup.Brown || g == ColorGroup.DarkBlue) ? 2 : 3;
+        }
+
+        private class Own : IOwnershipService
+        {
+            private readonly System.Collections.Generic.Dictionary<ITileRentInfo, Player> map =
+                new System.Collections.Generic.Dictionary<ITileRentInfo, Player>();
+
+            public void SetOwner(ITileRentInfo t, Player p) => map[t] = p;
+            public Player GetOwner(ITileRentInfo t) => map.TryGetValue(t, out var p) ? p : null;
+
+            public int CountOwnedInGroup(Player owner, ColorGroup group)
+            {
+                int c = 0;
+                foreach (var kv in map)
+                    if (kv.Value == owner && kv.Key.Type == TileType.Street && kv.Key.Group == group) c++;
+                return c;
+            }
+
+            public int CountRailroadsOwned(Player owner)
+            {
+                int c = 0;
+                foreach (var kv in map)
+                    if (kv.Value == owner && kv.Key.Type == TileType.Railroad) c++;
+                return c;
+            }
+
+            public bool OwnsBothUtilities(Player owner)
+            {
+                int c = 0;
+                foreach (var kv in map)
+                    if (kv.Value == owner && kv.Key.Type == TileType.Utility) c++;
+                return c >= 2;
+            }
+        }
+
+        private Player P(string name)
+        {
+            var p = ScriptableObject.CreateInstance<Player>();
+            p.SetPName(name);
+            p.SetMoney(9999);
+            return p;
+        }
+
+        [Test]
+        public void Street_NoHouses_NoMonopoly_Base()
+        {
+            var strat = new StandardRentStrategy();
+            var rules = new Rules();
+            var own = new Own();
+            var o = P("O");
+
+            var t = new Tile {
+                Name="Mediterranean", Type=TileType.Street, Group=ColorGroup.Brown,
+                BaseRent=2, HouseCount=0, RentByHouses=new[]{2,10,30,90,160,250}
+            };
+
+            own.SetOwner(t, o);
+            Assert.AreEqual(2, strat.ComputeRent(t, o, 0, own, rules));
+            Object.DestroyImmediate(o);
+        }
+
+        [Test]
+        public void Street_NoHouses_WithMonopoly_DoubleBase()
+        {
+            var strat = new StandardRentStrategy();
+            var rules = new Rules();
+            var own = new Own();
+            var o = P("O");
+
+            var t1 = new Tile { Name="Mediterranean", Type=TileType.Street, Group=ColorGroup.Brown, BaseRent=2, HouseCount=0, RentByHouses=new[]{2,10,30,90,160,250} };
+            var t2 = new Tile { Name="Baltic",        Type=TileType.Street, Group=ColorGroup.Brown, BaseRent=4, HouseCount=0, RentByHouses=new[]{4,20,60,180,320,450} };
+
+            own.SetOwner(t1, o);
+            own.SetOwner(t2, o);
+
+            Assert.AreEqual(4, strat.ComputeRent(t1, o, 0, own, rules));
+            Object.DestroyImmediate(o);
+        }
+
+        [Test]
+        public void Street_WithHouses_UsesTable()
+        {
+            var strat = new StandardRentStrategy();
+            var rules = new Rules();
+            var own = new Own();
+            var o = P("O");
+
+            var t = new Tile {
+                Name="Illinois", Type=TileType.Street, Group=ColorGroup.Red, BaseRent=20,
+                HouseCount=3, RentByHouses=new[]{20,100,300,750,925,1100}
+            };
+            own.SetOwner(t, o);
+
+            Assert.AreEqual(750, strat.ComputeRent(t, o, 0, own, rules));
+            Object.DestroyImmediate(o);
+        }
+
+        [Test]
+        public void Railroad_Scales_25_50_100_200()
+        {
+            var strat = new StandardRentStrategy();
+            var rules = new Rules();
+            var own = new Own();
+            var o = P("O");
+
+            var r1 = new Tile { Name="RR1", Type=TileType.Railroad };
+            var r2 = new Tile { Name="RR2", Type=TileType.Railroad };
+            var r3 = new Tile { Name="RR3", Type=TileType.Railroad };
+            var r4 = new Tile { Name="RR4", Type=TileType.Railroad };
+
+            own.SetOwner(r1, o);
+            Assert.AreEqual(25, strat.ComputeRent(r1, o, 0, own, rules));
+            own.SetOwner(r2, o);
+            Assert.AreEqual(50, strat.ComputeRent(r1, o, 0, own, rules));
+            own.SetOwner(r3, o);
+            Assert.AreEqual(100, strat.ComputeRent(r1, o, 0, own, rules));
+            own.SetOwner(r4, o);
+            Assert.AreEqual(200, strat.ComputeRent(r1, o, 0, own, rules));
+
+            Object.DestroyImmediate(o);
+        }
+
+        [Test]
+        public void Utility_UsesDice_Multipliers_4_and_10()
+        {
+            var strat = new StandardRentStrategy();
+            var rules = new Rules();
+            var own = new Own();
+            var o = P("O");
+
+            var u1 = new Tile { Name="Electric", Type=TileType.Utility };
+            var u2 = new Tile { Name="Water",    Type=TileType.Utility };
+
+            own.SetOwner(u1, o);
+            Assert.AreEqual(28, strat.ComputeRent(u1, o, 7, own, rules)); // 7*4
+
+            own.SetOwner(u2, o);
+            Assert.AreEqual(70, strat.ComputeRent(u1, o, 7, own, rules)); // 7*10
+
+            Object.DestroyImmediate(o);
+        }
+
+        [Test]
+        public void Mortgaged_ReturnsZero()
+        {
+            var strat = new StandardRentStrategy();
+            var rules = new Rules();
+            var own = new Own();
+            var o = P("O");
+
+            var t = new Tile {
+                Name="Park Place", Type=TileType.Street, Group=ColorGroup.DarkBlue,
+                BaseRent=35, HouseCount=0, IsMortgaged=true,
+                RentByHouses=new[]{35,175,500,1100,1300,1500}
+            };
+            own.SetOwner(t, o);
+
+            Assert.AreEqual(0, strat.ComputeRent(t, o, 0, own, rules));
+            Object.DestroyImmediate(o);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/RentTests/StandardRentStrategyTests.cs.meta
+++ b/Assets/Tests/EditMode/RentTests/StandardRentStrategyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa18f6e05dcf25447a41390df4762c10

--- a/UMLDiagrams/Task285.mmd
+++ b/UMLDiagrams/Task285.mmd
@@ -1,0 +1,106 @@
+classDiagram
+direction LR
+
+class Space {
+  <<abstract>>
+  +name: string
+  +index: int
+  +land(p: Player): void
+}
+
+class OwnableSpace {
+  +purchasePrice: int
+  +isMortgaged: bool
+  +owner: Player
+  +getRent(ctx: RentContext): int
+  +onLand(p: Player): void
+  +mortgage(): void
+  +unmortgage(): void
+}
+Space <|-- OwnableSpace
+
+class Property {
+  +color: ColorGroup
+  +houseCount: int
+  +hotelCount: int
+  +houseCost: int
+}
+OwnableSpace <|-- Property
+
+class Railroad {
+  +baseRent: int
+}
+OwnableSpace <|-- Railroad
+
+class Utility {
+  +note: "Rent uses dice roll"
+}
+OwnableSpace <|-- Utility
+
+class Player {
+  +name: string
+  +cash: int
+  +pay(amount: int, to: Player): void
+  +receive(amount: int): void
+  +ownsMonopoly(group: ColorGroup): bool
+  +countRailroads(): int
+  +countUtilities(): int
+}
+
+class RentContext {
+  +diceRoll: int
+  +ownerMonopoly: bool
+  +railroadsOwned: int
+  +utilitiesOwned: int
+}
+
+class RentStrategy {
+  <<interface>>
+  +calculateRent(space: OwnableSpace, ctx: RentContext): int
+}
+
+class StandardPropertyRentStrategy {
+  +calculateRent(space: OwnableSpace, ctx: RentContext): int
+}
+RentStrategy <|.. StandardPropertyRentStrategy
+
+class RailroadRentStrategy {
+  +calculateRent(space: OwnableSpace, ctx: RentContext): int
+}
+RentStrategy <|.. RailroadRentStrategy
+
+class UtilityRentStrategy {
+  +calculateRent(space: OwnableSpace, ctx: RentContext): int
+}
+RentStrategy <|.. UtilityRentStrategy
+
+OwnableSpace *-- RentStrategy : uses
+Player "1" <-- "0..1" OwnableSpace : owner
+
+class TitleDeed {
+  +name: string
+  +purchasePrice: int
+  +mortgageValue: int
+  +rent0H: int
+  +rent1H: int
+  +rent2H: int
+  +rent3H: int
+  +rent4H: int
+  +rentHotel: int
+}
+Property o-- TitleDeed
+Railroad o-- TitleDeed
+Utility  o-- TitleDeed
+
+class ColorGroup {
+  <<enumeration>>
+  +Brown
+  +LightBlue
+  +Pink
+  +Orange
+  +Red
+  +Yellow
+  +Green
+  +DarkBlue
+}
+Property --> ColorGroup


### PR DESCRIPTION
Completes tasks:
- Create StandardRentStrategy With ComputRent(tile, owner, state) (Task 281)
- Integrate with TileResolver and EconomyManager (Task 282)
- Support Houses and hotles scaling as well as setting bonuses (Task 283)
- Write tests to make sure rent logic is working properly  (Task 284)
- Create a class diagram for property, ownership, and rent strategy  (Task 285)

There are definitely going to be changes made to this code as we add in more rule sets like bankruptcies.  I added comments were the logic is going to need to change the most so it can be updated accordingly.  We are also going to need to figure out how we want to track the player money moving forward since it will be more complicated once more rules are added.  There is also a function in the RentManager that only needed for testing, it is explained in the comments. 

The diagram can be found in the google drive as well as the UML folder. 