### PR TITLE
US252 Turn Order Strategy

### DIFF
--- a/Assets/Scripts/Managers/TurnOrder.meta
+++ b/Assets/Scripts/Managers/TurnOrder.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82d32180b7ac55749bb455e1f8e73202
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/TurnOrder/ITurnOrderStrategy.cs
+++ b/Assets/Scripts/Managers/TurnOrder/ITurnOrderStrategy.cs
@@ -1,0 +1,11 @@
+namespace Assets.Scripts.Managers.TurnOrder
+{
+    public interface ITurnOrderStrategy
+    {
+        //Returns the next player index given current states
+        int NextPlayerIndex(int currentIndex, int playerCount, IPlayerTurnState state);
+
+        //Checks if player should immediately take another turn
+        bool HasExtraTurn(int currentIndex, IPlayerTurnState state); 
+    }
+}

--- a/Assets/Scripts/Managers/TurnOrder/ITurnOrderStrategy.cs.meta
+++ b/Assets/Scripts/Managers/TurnOrder/ITurnOrderStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b649aeb02e5309f46b83fabfc07e40e7

--- a/Assets/Scripts/Managers/TurnOrder/PlayerTurnState.cs
+++ b/Assets/Scripts/Managers/TurnOrder/PlayerTurnState.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;   
+using UnityEngine;
+
+namespace Assets.Scripts.Managers.TurnOrder
+{
+    //Encapsulates per-player turn flags used by the strategy
+    public interface IPlayerTurnState
+    {
+        bool IsEliminated(int playerIndex);
+        bool IsSkippedThisRound(int playerIndex);
+        void ConsumeSkip(int playerIndex);
+
+        bool GetExtraTurn(int playerIndex);
+        void SetExtraTurn(int playerIndex, bool value);
+    }
+
+    //Default in memory implementation
+    //This can be chagned once we know all game states later
+    public class PlayerTurnState : MonoBehaviour, IPlayerTurnState
+    {
+        [SerializeField] private List<bool> eliminated = new();
+        [SerializeField] private List<int>  skipCounts = new(); //number of turns to skip
+        [SerializeField] private List<bool> extraTurn  = new();
+
+        public void EnsureSize(int count)
+        {
+            while (eliminated.Count < count) eliminated.Add(false);
+            while (skipCounts.Count < count) skipCounts.Add(0);
+            while (extraTurn.Count  < count) extraTurn.Add(false);
+        }
+
+
+        //IPlayerTurnState
+        public bool IsEliminated(int playerIndex)           
+        { 
+            EnsureSize(playerIndex + 1); 
+            return eliminated[playerIndex]; 
+        }
+
+        public bool IsSkippedThisRound(int playerIndex)     
+        { 
+            EnsureSize(playerIndex + 1); 
+            return skipCounts[playerIndex] > 0; 
+        }
+
+        public void ConsumeSkip(int playerIndex)            
+        { 
+            EnsureSize(playerIndex + 1); 
+            if (skipCounts[playerIndex] > 0) 
+            {
+                skipCounts[playerIndex]--;
+            }  
+        }
+
+        public bool GetExtraTurn(int playerIndex)           
+        { 
+            EnsureSize(playerIndex + 1); 
+            return extraTurn[playerIndex]; 
+        }
+
+        public void SetExtraTurn(int playerIndex, bool val) 
+        { 
+            EnsureSize(playerIndex + 1); 
+            extraTurn[playerIndex] = val; 
+        }
+    }
+}

--- a/Assets/Scripts/Managers/TurnOrder/PlayerTurnState.cs
+++ b/Assets/Scripts/Managers/TurnOrder/PlayerTurnState.cs
@@ -29,6 +29,25 @@ namespace Assets.Scripts.Managers.TurnOrder
             while (extraTurn.Count  < count) extraTurn.Add(false);
         }
 
+        //Completes task 273
+        //This wil have to be updated in the second semester once we add more logic
+        public void Eliminate(int idx)
+        { 
+            EnsureSize(idx + 1);
+            eliminated[idx] = true;
+        }
+
+        public void AddSkip(int idx, int n)
+        {
+            EnsureSize(idx + 1);
+            skipCounts[idx] += Mathf.Max(1, n);
+        }
+
+        public void GrantExtraTurn(int idx)
+        { 
+            EnsureSize(idx + 1);
+            extraTurn[idx] = true;
+        }
 
         //IPlayerTurnState
         public bool IsEliminated(int playerIndex)           

--- a/Assets/Scripts/Managers/TurnOrder/PlayerTurnState.cs.meta
+++ b/Assets/Scripts/Managers/TurnOrder/PlayerTurnState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b595c2537c41cf4aa3bdb014a86245d

--- a/Assets/Scripts/Managers/TurnOrder/StandardTurnOrderStrategy.cs
+++ b/Assets/Scripts/Managers/TurnOrder/StandardTurnOrderStrategy.cs
@@ -1,0 +1,48 @@
+namespace Assets.Scripts.Managers.TurnOrder
+{
+    //Standard Monopoly turn order
+    //If current player has an extra turn then they go again and flag is cleared
+    //else it goes to next non eliminated player consuming one skip if present
+    //Wraps around the player list.
+
+    public class StandardTurnOrderStrategy : ITurnOrderStrategy
+    {
+        public bool HasExtraTurn(int currentIndex, IPlayerTurnState state)
+        {
+            return state.GetExtraTurn(currentIndex);
+        }
+
+        public int NextPlayerIndex(int currentIndex, int playerCount, IPlayerTurnState state)
+        {
+            //If the current player has an extra turn then clear it and keep same index
+            if (state.GetExtraTurn(currentIndex))
+            {
+                state.SetExtraTurn(currentIndex, false);
+                return currentIndex;
+            }
+
+            //Otherwise move forward until there is a playable player
+            int attempts = 0;
+            int idx = currentIndex;
+
+            while (attempts < playerCount)
+            {
+                idx = (idx + 1) % playerCount;
+                attempts++;
+
+                if (state.IsEliminated(idx)) continue;
+
+                if (state.IsSkippedThisRound(idx))
+                {
+                    state.ConsumeSkip(idx);
+                    continue;
+                }
+
+                return idx; //found next
+            }
+
+            //If everyone is eliminated or skipped then just return current
+            return currentIndex;
+        }
+    }
+}

--- a/Assets/Scripts/Managers/TurnOrder/StandardTurnOrderStrategy.cs.meta
+++ b/Assets/Scripts/Managers/TurnOrder/StandardTurnOrderStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b81403a5c2d67e4c871cf68e8460a0c

--- a/Assets/Scripts/Managers/TurnOrder/TurnCycleManager.cs
+++ b/Assets/Scripts/Managers/TurnOrder/TurnCycleManager.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+namespace Assets.Scripts.Managers.TurnOrder
+{
+    //Manager that controls the turn index and asks strategy for who goes next
+    //Self-wires in EditMode and Play mode testing
+    public class TurnCycleManager : MonoBehaviour
+    {
+        [Header("Config")]
+        [SerializeField] private int playerCount = 4;
+        [SerializeField] private int startingPlayerIndex = 0;
+
+        [Header("Dependencies")]
+        [SerializeField] private PlayerTurnState playerTurnState;
+        [SerializeField] private GameManager gameManager; //To raise existing events if needed
+
+        private ITurnOrderStrategy strategy = new StandardTurnOrderStrategy();
+
+        public int CurrentPlayerIndex { get; private set; }
+
+        private void Awake()
+        {
+            EnsureDeps();
+            ResetCycle(playerCount, startingPlayerIndex);
+        }
+
+        private void EnsureDeps()
+        {
+            if (!playerTurnState)
+                playerTurnState = GetComponent<PlayerTurnState>() ?? gameObject.AddComponent<PlayerTurnState>();
+
+            if (!gameManager)
+            {
+                gameManager = Object.FindFirstObjectByType<GameManager>();
+            }
+        }
+
+        public void ResetCycle(int count, int startIndex = 0)
+        {
+            EnsureDeps();
+            playerCount = Mathf.Max(2, count);
+            playerTurnState.EnsureSize(playerCount);
+            CurrentPlayerIndex = Mathf.Clamp(startIndex, 0, playerCount - 1);
+        }
+
+        //Call when a turn ends
+        //Moves to next player or repeats if extra turn 
+        public int Advance()
+        {
+            EnsureDeps();
+            int next = strategy.NextPlayerIndex(CurrentPlayerIndex, playerCount, playerTurnState);
+
+            CurrentPlayerIndex = next;
+
+            if (gameManager && gameManager.turnStartedChannel != null)
+                gameManager.turnStartedChannel.RaiseEvent(new TurnStartedEvent(CurrentPlayerIndex, 0)); 
+
+            return CurrentPlayerIndex;
+        }
+
+        //hooks to alter state from other systems
+        public void GrantExtraTurn(int playerIndex) => playerTurnState.GrantExtraTurn(playerIndex);
+        public void AddSkip(int playerIndex, int count = 1) => playerTurnState.AddSkip(playerIndex, count);
+        public void Eliminate(int playerIndex) => playerTurnState.Eliminate(playerIndex);
+    }
+}

--- a/Assets/Scripts/Managers/TurnOrder/TurnCycleManager.cs.meta
+++ b/Assets/Scripts/Managers/TurnOrder/TurnCycleManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e085021e29291604c922653112a06bd8

--- a/Assets/Tests/EditMode/TurnOrderTests.meta
+++ b/Assets/Tests/EditMode/TurnOrderTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c6ad31de43118249a686f0b3672bced
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/TurnOrderTests/StandardTurnOrderStrategyTests.cs
+++ b/Assets/Tests/EditMode/TurnOrderTests/StandardTurnOrderStrategyTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using UnityEngine;
+using Assets.Scripts.Managers.TurnOrder;
+
+namespace Tests.EditMode.TurnOrderTests
+{
+    public class StandardTurnOrderStrategyTests
+    {
+        private ITurnOrderStrategy strat;
+        private PlayerTurnState state;
+
+        [SetUp]
+        public void SetUp()
+        {
+            strat = new StandardTurnOrderStrategy();
+            state = new GameObject("state").AddComponent<PlayerTurnState>();
+            state.EnsureSize(4);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(state.gameObject);
+        }
+
+        [Test]
+        public void Normal_Advance_Wraps()
+        {
+            Assert.AreEqual(1, strat.NextPlayerIndex(0, 4, state));
+            Assert.AreEqual(2, strat.NextPlayerIndex(1, 4, state));
+            Assert.AreEqual(3, strat.NextPlayerIndex(2, 4, state));
+            Assert.AreEqual(0, strat.NextPlayerIndex(3, 4, state));
+        }
+
+        [Test]
+        public void ExtraTurn_Repeats_And_Clears()
+        {
+            state.GrantExtraTurn(2);
+            //First call stays at 2
+            Assert.AreEqual(2, strat.NextPlayerIndex(2, 4, state));
+            //flag should have been cleared
+            // The next player should be 3
+            Assert.AreEqual(3, strat.NextPlayerIndex(2, 4, state));
+        }
+
+        [Test]
+        public void Skip_Consumes_And_Jumps()
+        {
+            state.AddSkip(1, 1);
+            Assert.AreEqual(2, strat.NextPlayerIndex(0, 4, state)); //1 is skipped
+            //next turn should be plauer 1 again
+            Assert.AreEqual(1, strat.NextPlayerIndex(0, 4, state));
+        }
+
+        [Test]
+        public void Eliminated_Is_Skipped_Permanently()
+        {
+            state.Eliminate(1);
+            Assert.AreEqual(2, strat.NextPlayerIndex(0, 4, state));
+            Assert.AreEqual(3, strat.NextPlayerIndex(2, 4, state));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/TurnOrderTests/StandardTurnOrderStrategyTests.cs.meta
+++ b/Assets/Tests/EditMode/TurnOrderTests/StandardTurnOrderStrategyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bfc3e3df11c54c54f999b6975c27382e

--- a/Assets/Tests/EditMode/TurnOrderTests/TurnCycleManagerIntegrationTests.cs
+++ b/Assets/Tests/EditMode/TurnOrderTests/TurnCycleManagerIntegrationTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using Assets.Scripts.Managers.TurnOrder;
+
+namespace Tests.EditMode.TurnOrderTests
+{
+    public class TurnCycleManagerIntegrationTests : TurnOrderTestBase
+    {
+        [Test]
+        public void Advance_Normal_Sequence()
+        {
+            Assert.AreEqual(1, cycle.Advance()); //from 0 to 1
+            Assert.AreEqual(2, cycle.Advance()); //from 1 to 2
+            Assert.AreEqual(3, cycle.Advance()); //from 2 to 3
+            Assert.AreEqual(0, cycle.Advance()); //from 3 to 0, wrap
+        }
+
+        [Test]
+        public void Advance_Honors_ExtraTurn()
+        {
+            cycle.GrantExtraTurn(0);
+            Assert.AreEqual(0, cycle.Advance()); //extra turn for 0
+            Assert.AreEqual(1, cycle.Advance()); //continue 
+        }
+
+        [Test]
+        public void Advance_Consumes_Skip()
+        {
+            cycle.AddSkip(1, 1);
+            Assert.AreEqual(2, cycle.Advance()); //1 is skipped
+            Assert.AreEqual(3, cycle.Advance()); //from 2 to 3
+            Assert.AreEqual(0, cycle.Advance()); //from 3 to 0
+            Assert.AreEqual(1, cycle.Advance()); //from 0 to 1, skip is used
+        }
+
+        [Test]
+        public void Advance_Skips_Eliminated()
+        {
+            cycle.Eliminate(1);
+            Assert.AreEqual(2, cycle.Advance()); //from 0 to 2
+            Assert.AreEqual(3, cycle.Advance()); //from 2 to 3
+            Assert.AreEqual(0, cycle.Advance()); //from 3 to 0
+        }
+    }
+}

--- a/Assets/Tests/EditMode/TurnOrderTests/TurnCycleManagerIntegrationTests.cs.meta
+++ b/Assets/Tests/EditMode/TurnOrderTests/TurnCycleManagerIntegrationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c6d5610e2896a5b4d819245daff8d55e

--- a/Assets/Tests/EditMode/TurnOrderTests/TurnOrderTestBase.cs
+++ b/Assets/Tests/EditMode/TurnOrderTests/TurnOrderTestBase.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UnityEngine;
+using Tests.EditMode;
+using Assets.Scripts.Managers.TurnOrder;
+
+namespace Tests.EditMode.TurnOrderTests
+{
+    public class TurnOrderTestBase : ManagerTestBase
+    {
+        protected GameObject go;
+        protected TurnCycleManager cycle;
+        protected PlayerTurnState  state;
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            go    = new GameObject("TurnCycle");
+            cycle = go.AddComponent<TurnCycleManager>();
+            state = go.AddComponent<PlayerTurnState>();
+            //Reset manager with 4 players and starts at 0
+            cycle.ResetCycle(4, 0);
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            DestroyTestObjects(go);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/TurnOrderTests/TurnOrderTestBase.cs.meta
+++ b/Assets/Tests/EditMode/TurnOrderTests/TurnOrderTestBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c15ef05cccebb1747b1b791080b7da35

--- a/UMLDiagrams/Task275.mmd
+++ b/UMLDiagrams/Task275.mmd
@@ -1,0 +1,39 @@
+sequenceDiagram
+    autonumber
+    participant GM as GameManager
+    participant TCM as TurnCycleManager
+    participant PTS as PlayerTurnState
+    participant STR as StandardTurnOrderStrategy
+
+    GM->>TCM: EndTurn() / Advance()
+    TCM->>TCM: Ensure dependencies 
+    TCM->>PTS: EnsureSize(playerCount)
+
+    TCM->>STR: NextPlayerIndex(currentIndex, playerCount, PTS)
+    alt Current player has Extra Turn
+        STR-->>TCM: currentIndex (clear extra turn flag)
+        Note over TCM: Extra turn used so same player goes again
+    else Advance to next playable
+        STR-->>TCM: nextIndex
+    end
+
+    opt Skip or Eliminated encountered
+        TCM->>PTS: IsSkippedThisRound get nextIndex
+        alt Skipped
+            PTS-->>TCM: true (use 1 turn)
+            TCM->>STR: NextPlayerIndex(nextIndex, playerCount, PTS)
+            STR-->>TCM: nextPlayableIndex
+        else Not Skipped
+            TCM->>PTS: IsEliminated(nextIndex)?
+            alt Eliminated
+                PTS-->>TCM: true (skip permanently)
+                TCM->>STR: NextPlayerIndex(nextIndex, playerCount, PTS)
+                STR-->>TCM: nextPlayableIndex
+            else Playable
+                PTS-->>TCM: false
+            end
+        end
+    end
+
+    TCM->>GM: turnStartedChannel.Raise(CurrentPlayerIndex)
+    GM-->>GM: Begin next player's turn


### PR DESCRIPTION
Tasks Completed:
- Implement StandardTurnOrderStrategy (Task 271)
- Integrate into TurnCycleManager (Task 272)
- Handle skips, extra turns, and eliminated players (Task 273)
- Create EditMode tests for all files created (Task 274)
- Create Sequence Diagram for Turn Order Strategy (Task 275)

More logic will need to be implemented as more rulesets are added such as bankruptcy so there is some placeholder code which is marked in the files.  There are a few methods that were created for testing as well and are labeled.  Sequence diagram can also be found in UML folder in the Google Drive. 