### PR TITLE
US253: As a player, I want consistent movement rules so that I can roll dice and then move pieces with predictable order

### DIFF
--- a/Assets/Scripts/Board/BoardManager.cs
+++ b/Assets/Scripts/Board/BoardManager.cs
@@ -157,12 +157,21 @@ namespace PsycheOpoly.Board{
         {
             EnsureBoard();
             int previous = GetPlayerPosition(mpe.id);
-            int next = NormalizeIndex(previous + mpe.spacesToMove);
+            int spaces = mpe.spacesToMove;
+            int next = NormalizeIndex(previous + spaces);
+
+            //path indces from prev to next to be traces
+            int[] path = new int[spaces];
+            for (int i = 0; i<spaces; i++)
+            {
+                path[i] = NormalizeIndex(previous + i + 1);
+            }
+
             Logger.Debug("Move Player", 
                 $"Player {mpe.id} moved {mpe.spacesToMove}, from {previous} to {previous+mpe.spacesToMove}, normalized: {next}", 
                 LogCategory.Gameplay, this);
             playerPositions[mpe.id] = next;
-            playerMovedChannel?.RaiseEvent(new PlayerMovedEvent(mpe.id, previous, next));
+            playerMovedChannel?.RaiseEvent(new PlayerMovedEvent(mpe.id, previous, next, path));
             // Throws an event if the player has a negative move.
             // This may need a refactor if anything causes the player to move backwards normally.
             if (next < previous)

--- a/Assets/Scripts/Board/BoardManager.cs
+++ b/Assets/Scripts/Board/BoardManager.cs
@@ -160,12 +160,27 @@ namespace PsycheOpoly.Board{
             int spaces = mpe.spacesToMove;
             int next = NormalizeIndex(previous + spaces);
 
-            //path indces from prev to next to be traces
-            int[] path = new int[spaces];
-            for (int i = 0; i<spaces; i++)
+            //more robust path building code
+            int steps = Mathf.Abs(spaces);
+            int[] path = new int[steps];
+
+            if (spaces > 0)
             {
-                path[i] = NormalizeIndex(previous + i + 1);
+                //moving forward
+                for (int i = 0; i < steps; i++)
+                {
+                    path[i] = NormalizeIndex(previous + (i + 1));
+                }
             }
+            else if (spaces < 0)
+            {
+                //moving backward
+                for (int i = 0; i < steps; i++)
+                {
+                    path[i] = NormalizeIndex(previous - (i + 1));
+                }
+            }
+            // if spaces == 0 then path = empty
 
             Logger.Debug("Move Player", 
                 $"Player {mpe.id} moved {mpe.spacesToMove}, from {previous} to {previous+mpe.spacesToMove}, normalized: {next}", 

--- a/Assets/Scripts/Board/BoardManager.cs
+++ b/Assets/Scripts/Board/BoardManager.cs
@@ -189,7 +189,8 @@ namespace PsycheOpoly.Board{
             playerMovedChannel?.RaiseEvent(new PlayerMovedEvent(mpe.id, previous, next, path));
             // Throws an event if the player has a negative move.
             // This may need a refactor if anything causes the player to move backwards normally.
-            if (next < previous)
+            //fixed bc only forward movement through a full wrap-around should trigger passedGo
+            if (spaces > 0 && next < previous)
             {
                 passedGoChannel?.RaiseEvent(mpe.id);
             }

--- a/Assets/Scripts/Board/BoardRenderer.cs
+++ b/Assets/Scripts/Board/BoardRenderer.cs
@@ -183,7 +183,7 @@ public class BoardRenderer : MonoBehaviour
         playerPieces = playerPieces.OrderBy(playerPiece => playerPiece.playerId).ToList();
         
         // move the piece to the starting location (GO)
-        MovePiece(new PlayerMovedEvent(piece.playerId, 0,0));
+        MovePiece(new PlayerMovedEvent(piece.playerId, 0, 0, null));
     }
 
     /// <summary>

--- a/Assets/Scripts/Events/EventDataStructures/MovePlayerEvent.cs
+++ b/Assets/Scripts/Events/EventDataStructures/MovePlayerEvent.cs
@@ -17,7 +17,11 @@ public class MovePlayerEvent
 
     public int spacesToMove { get; private set; }
 
-
+    /// <summary>
+    /// ordered list of board indices the player will traverse. Used by animation systems or to pre-define 
+    /// the movement path.
+    /// </summary>
+    public int[] pathIndices { get; private set; }
 
 
     /// <summary>
@@ -26,9 +30,11 @@ public class MovePlayerEvent
     /// </summary>
     /// <param name="playerId"><b>READ-ONLY:</b> ID of the <c>Player</c></param>
     /// <param name="spacesToMove"><b>READ-ONLY:</b> Amount of spaces to move <c>Player</c></param>
-    public MovePlayerEvent(int playerId, int spacesToMove)
+    /// /// <param name="pathIndices">
+    public MovePlayerEvent(int playerId, int spacesToMove, int[] pathIndices = null)
     {
         this.id = playerId;
         this.spacesToMove = spacesToMove;
+        this.pathIndices = pathIndices ?? new int[0];
     }
 }

--- a/Assets/Scripts/Events/EventDataStructures/PlayerMovedEvent.cs
+++ b/Assets/Scripts/Events/EventDataStructures/PlayerMovedEvent.cs
@@ -10,13 +10,19 @@ public class PlayerMovedEvent
     /// </summary>
     public int id { get; private set; }
     /// <summary>
-    /// The previous position of the Player that was moved.
+    /// The previous position of the Player that was moved.     this represents the FROM
     /// </summary>
     public int previousPosition { get; private set; }
     /// <summary>
-    /// The current position of the Player that was moved.
+    /// The current position of the Player that was moved.      this represents the TO
     /// </summary>
     public int newPosition { get; private set; }
+
+    /// <summary>
+    /// The ordered list of board indices the player traveled over. allows animation controllers to visualize each step.
+    /// </summary>
+    public int[] pathIndices { get; private set; }
+
 
     /// <summary>
     /// Creates a <b>READ-ONLY</b> payload of data regarding a Player moving to be used
@@ -25,10 +31,11 @@ public class PlayerMovedEvent
     /// <param name="id"><b>READ-ONLY:</b> ID of the <c>Player</c></param>
     /// <param name="previousPosition"><b>READ-ONLY:</b> previous <c>Player</c> position</param>
     /// <param name="newPosition"><b>READ-ONLY:</b> new/current <c>Player</c> position</param>
-    public PlayerMovedEvent(int id, int previousPosition, int newPosition)
+    public PlayerMovedEvent(int id, int previousPosition, int newPosition, int[] pathIndices)
     {
         this.id = id;
         this.previousPosition = previousPosition;
         this.newPosition = newPosition;
+        this.pathIndices = pathIndices ?? new int[0];
     }
 }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -2,6 +2,8 @@ using System.Collections;
 using UnityEngine;
 using System.Collections.Generic;
 using Logging;
+using PsycheOpoly.Board;
+using Assets.Scripts.Managers.Movement;
 
 public class GameManager : MonoBehaviour
 {
@@ -24,7 +26,10 @@ public class GameManager : MonoBehaviour
     [SerializeField] public DiceRolledEventChannel diceRolledChannel;
     [SerializeField] public MovePlayerEventChannel movePlayerChannel;
     [SerializeField] public BooleanEventChannel pieceMoveCompletedChannel;
-    
+    [SerializeField] private DiceManager diceManager;
+    [SerializeField] private BoardManager boardManager;
+    [SerializeField] private StandardMovementStrategy movementStrategy;
+
 
     private int playerCount = 0;
     private int currentPlayer = 0;
@@ -100,6 +105,28 @@ public class GameManager : MonoBehaviour
         //US156T157 subscribe to DiceRolled Listener
         diceRolledChannel.Subscribe(DiceRolled);
         pieceMoveCompletedChannel?.Subscribe(PieceMoveCompleted);
+
+        //us253-t278 hook up movement strategy to dice/board managers
+        if (movementStrategy != null)
+        {
+            movementStrategy.enabled = true;
+
+            Logging.Logger.Info("GameManager.Start", "StandardMovementStrategy active and listening.",
+                Logging.LogCategory.Core, this);
+        }
+        else
+        {
+            Logging.Logger.Warn("GameManager.Start", "StandardMovementStrategy not assigned in Inspector.",
+                Logging.LogCategory.Core, this);
+        }
+
+        if (boardManager == null)
+            Logging.Logger.Warn("GameManager.Start", "BoardManager reference not assigned.",
+                Logging.LogCategory.Core, this);
+
+        if (diceManager == null)
+            Logging.Logger.Warn("GameManager.Start", "DiceManager reference not assigned.", 
+                Logging.LogCategory.Core, this);
     }
 
     //start & end game to satisfy us11-35
@@ -326,7 +353,10 @@ public class GameManager : MonoBehaviour
 
         if (this.gameState == GameState.PlayerTurn)
         {
-            movePlayerChannel?.RaiseEvent(new MovePlayerEvent(this.currentPlayer, this.totalRolled));
+            // movement now handled by StandardMovementStrategy. no need to raise MovePlayerEvent manually.
+            Logging.Logger.Debug("gameManager.DiceRolled", "Dice roll processed — movement handled by " +
+                "StandardMovementStrategy.",
+                Logging.LogCategory.Gameplay, this);
         }
     }
 }

--- a/Assets/Scripts/Managers/Movement.meta
+++ b/Assets/Scripts/Managers/Movement.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ffbda1d92933bc42b2861e15918a1c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/Movement/IMovementStrategy.cs
+++ b/Assets/Scripts/Managers/Movement/IMovementStrategy.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+
+namespace Assets.Scripts.Managers.Movement
+{
+
+
+    /// <summary>
+    /// Defines the interface for all movement strategies in Psyche-Opoly.
+    /// Each strategy determines how dice results translate into movement,
+    /// and how a turn resolves after movement completes.
+    /// </summary>
+    public interface IMovementStrategy
+    {
+
+        /// <summary>
+        /// Called when a dice roll occurs. also handles movement logic, doubles, and path creation.
+        /// </summary>
+        /// <param name="diceEvent">Result of the dice roll.</param>
+        void OnDiceRolled(DiceRolledEvent diceEvent);
+
+        /// <summary>
+        /// Called when a piece finishes its movement animation. used to resolve landing logic or trigger re-rolls.
+        /// </summary>
+        /// <param name="success">True if movement finished normally.</param>
+        void OnPieceMoveCompleted(bool success);
+
+    }
+}

--- a/Assets/Scripts/Managers/Movement/IMovementStrategy.cs.meta
+++ b/Assets/Scripts/Managers/Movement/IMovementStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61653c4c0bf8aa4489efa9c897200ebb

--- a/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
+++ b/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
@@ -26,6 +26,8 @@ namespace Assets.Scripts.Managers.Movement
 
         private int doublesCount = 0;
         private Player currentPlayer;
+        private PlayerManager playerManager;
+
 
         private void OnEnable()
         {
@@ -53,23 +55,29 @@ namespace Assets.Scripts.Managers.Movement
             currentPlayer = p;
         }
 
-        private void OnTurnStarted(TurnStartedEvent turnData)
+        private void Awake()
         {
-            // find the PlayerManager in the scene
-            PlayerManager pm = FindObjectOfType<PlayerManager>();
-
-            if (pm == null)
+            playerManager = FindObjectOfType<PlayerManager>();
+            if (playerManager == null)
             {
-                Logger.Error("StandardMovementStrategy.OnTurnStarted", "PlayerManager not found in scene.",
+                Logger.Error("StandardMovementStrategy.Awake", "PlayerManager not found in scene.",
                     LogCategory.Gameplay, this);
-                return;
             }
 
-            Player p = pm.GetPlayer(turnData.playerId);
+        }
+
+
+        private void OnTurnStarted(TurnStartedEvent turnData)
+        {
+            if (playerManager == null)
+                return;
+
+
+            Player p = playerManager.GetPlayer(turnData.playerId);
 
             if (p == null)
             {
-                Logger.Error("StandardMovementStrategy.OnTurnStarted", $"Could not resolve Player for ID {turnData.playerId}",
+                Logger.Error("StandardMovementStrategy.OnTurnStarted", $"Invalid playerId {turnData.playerId}",
                     LogCategory.Gameplay, this);
                 return;
 

--- a/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
+++ b/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
@@ -21,6 +21,7 @@ namespace Assets.Scripts.Managers.Movement
         [SerializeField] private DiceRolledEventChannel diceRolledChannel;
         [SerializeField] private MovePlayerEventChannel movePlayerChannel;
         [SerializeField] private BooleanEventChannel pieceMoveCompletedEventChannel;
+        [SerializeField] private TurnStartedEventChannel turnStartedEventChannel;
         [SerializeField] private IntEventChannel goToJailChannel;
 
         private int doublesCount = 0;
@@ -31,6 +32,7 @@ namespace Assets.Scripts.Managers.Movement
             diceRolledChannel?.Subscribe(OnDiceRolled);
             pieceMoveCompletedEventChannel?.Subscribe(OnPieceMoveCompleted);
             currentPlayerChannel?.Subscribe(SetCurrentPlayer);
+            turnStartedEventChannel?.Subscribe(OnTurnStarted);
         }
 
 
@@ -39,6 +41,7 @@ namespace Assets.Scripts.Managers.Movement
             diceRolledChannel?.Unsubscribe(OnDiceRolled);
             pieceMoveCompletedEventChannel?.Unsubscribe(OnPieceMoveCompleted);
             currentPlayerChannel?.Unsubscribe(SetCurrentPlayer);
+            turnStartedEventChannel?.Unsubscribe(OnTurnStarted);
 
         }
 
@@ -49,6 +52,33 @@ namespace Assets.Scripts.Managers.Movement
         {
             currentPlayer = p;
         }
+
+        private void OnTurnStarted(TurnStartedEvent turnData)
+        {
+            // find the PlayerManager in the scene
+            PlayerManager pm = FindObjectOfType<PlayerManager>();
+
+            if (pm == null)
+            {
+                Logger.Error("StandardMovementStrategy.OnTurnStarted", "PlayerManager not found in scene.",
+                    LogCategory.Gameplay, this);
+                return;
+            }
+
+            Player p = pm.GetPlayer(turnData.playerId);
+
+            if (p == null)
+            {
+                Logger.Error("StandardMovementStrategy.OnTurnStarted", $"Could not resolve Player for ID {turnData.playerId}",
+                    LogCategory.Gameplay, this);
+                return;
+
+
+            }
+
+            SetCurrentPlayer(p);
+        }
+
 
 
         public void OnDiceRolled(DiceRolledEvent diceEvent)

--- a/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
+++ b/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Assets.Scripts.Managers.Movement
+{
+    class StandardMovementStrategy
+    {
+    }
+}

--- a/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
+++ b/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs
@@ -1,12 +1,164 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UnityEngine;
+using PsycheOpoly.Board;
+using Logging;
+using Logger = Logging.Logger;
+using Space = PsycheOpoly.Board.Space;
 
 namespace Assets.Scripts.Managers.Movement
 {
-    class StandardMovementStrategy
+    /// <summary>
+    /// Default rule-driven movement strategy for Psyche-Opoly.
+    /// Handles dice rolls, doubles, jail logic, and post-move resolution.
+    /// </summary>
+    public class StandardMovementStrategy : MonoBehaviour, IMovementStrategy
     {
+        [Header("Dependencies")]
+        [SerializeField] private BoardManager boardManager;
+        [SerializeField] private PlayerEventChannel currentPlayerChannel;
+
+        [Header("Event Channels")]
+        [SerializeField] private DiceRolledEventChannel diceRolledChannel;
+        [SerializeField] private MovePlayerEventChannel movePlayerChannel;
+        [SerializeField] private BooleanEventChannel pieceMoveCompletedEventChannel;
+        [SerializeField] private IntEventChannel goToJailChannel;
+
+        private int doublesCount = 0;
+        private Player currentPlayer;
+
+        private void OnEnable()
+        {
+            diceRolledChannel?.Subscribe(OnDiceRolled);
+            pieceMoveCompletedEventChannel?.Subscribe(OnPieceMoveCompleted);
+            currentPlayerChannel?.Subscribe(SetCurrentPlayer);
+        }
+
+
+        private void OnDisable()
+        {
+            diceRolledChannel?.Unsubscribe(OnDiceRolled);
+            pieceMoveCompletedEventChannel?.Unsubscribe(OnPieceMoveCompleted);
+            currentPlayerChannel?.Unsubscribe(SetCurrentPlayer);
+
+        }
+
+        /// <summary>
+        /// sets/updates current active player (injected via GameManager or TurnSystem).
+        /// </summary>
+        private void SetCurrentPlayer(Player p)
+        {
+            currentPlayer = p;
+        }
+
+
+        public void OnDiceRolled(DiceRolledEvent diceEvent)
+        {
+            if (currentPlayer == null)
+            {
+                Logger.Warn("StandardMovementStrategy.OnDiceRolled",
+                    "No current player set.", LogCategory.Gameplay, this);
+                return;
+            }
+
+            int die1 = diceEvent.dieOne;
+            int die2 = diceEvent.dieTwo;
+            int total = diceEvent.totalRoll;
+
+            bool isDouble = die1 == die2;
+            if (isDouble) doublesCount++;
+            else doublesCount = 0;
+
+            // Triple doubles → Go To Jail
+            if (doublesCount >= 3)
+            {
+                Logger.Info("StandardMovementStrategy",
+                    "Triple doubles rolled → Sending player to Jail",
+                    LogCategory.Gameplay, this);
+
+                doublesCount = 0;
+
+
+                //TODO:
+                // goToJailChannel, for now, is an IntEventChannel used to notify the JailManager 
+                // (or any other subscribed system) that a player should be sent to jail.
+                // since there is no JailManager logic is implemented, this call will do nothing 
+                // unless a listener subscribes. this is just a fallback  to ensure the player is still 
+                // sent to the Jail space (placheolder of index 10) so that the core behavior stil holds.
+                if (goToJailChannel != null)
+                    goToJailChannel.RaiseEvent(currentPlayer.GetId());
+                else
+                    boardManager.SetPlayerPosition(currentPlayer.GetId(), 10); //TODO: change to ACTUAL jail index
+
+                return;
+            }
+
+            // Standard movement
+            int startIndex = boardManager.GetPlayerPosition(currentPlayer.GetId());
+            int endIndex = NormalizeIndex(startIndex + total, boardManager.boardSize);
+
+            int[] pathIndices = BuildPathIndices(startIndex, total, boardManager.boardSize);
+
+            Logger.Debug("StandardMovementStrategy",
+                $"Player {currentPlayer.GetId()} rolled {die1}+{die2}={total} moving from {startIndex}→{endIndex}",
+                LogCategory.Gameplay, this);
+
+
+
+            MovePlayerEvent moveEvent = new MovePlayerEvent(currentPlayer.GetId(), total, pathIndices);
+            movePlayerChannel?.RaiseEvent(moveEvent);
+        }
+
+        public void OnPieceMoveCompleted(bool success)
+        {
+            if (!success || currentPlayer == null)
+                return;
+
+
+
+            int playerId = currentPlayer.GetId();
+            int currentPos = boardManager.GetPlayerPosition(playerId);
+            Space landed = boardManager.GetSpace(currentPos);
+
+            Logger.Info("StandardMovementStrategy",
+                $"Player {playerId} landed on {landed?.GetType().Name ?? "Unknown"} (Index {currentPos})",
+                LogCategory.Gameplay, this);
+
+            //landing effect for the space
+            landed?.OnLanded(currentPlayer);
+
+            //handles the doubles roll logic
+            if (doublesCount > 0)
+            {
+                Logger.Debug("StandardMovementStrategy", "Doubles → allow re-roll", LogCategory.Gameplay, this);
+                //this is where we can put a re-roll button...
+                //recall also, we defined 3 doubles rolls is a jail sentence!
+            }
+            else
+            {
+                Logger.Debug("StandardMovementStrategy", "Turn complete.", LogCategory.Gameplay, this);
+                doublesCount = 0;
+            }
+        }
+
+        //helprs
+
+        private static int NormalizeIndex(int raw, int boardSize)
+        {
+            if (boardSize <= 0) return 0;
+            int idx = raw % boardSize;
+            return idx < 0 ? idx + boardSize : idx;
+        }
+
+        private static int[] BuildPathIndices(int startIndex, int spacesToMove, int boardSize)
+        {
+            int[] path = new int[spacesToMove];
+            for (int i = 0; i < spacesToMove; i++)
+            {
+                path[i] = NormalizeIndex(startIndex + i + 1, boardSize);
+            }
+
+            return path;
+        }
+
     }
 }

--- a/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs.meta
+++ b/Assets/Scripts/Managers/Movement/StandardMovementStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad2c1d154ce554040a632cf77eeac9aa

--- a/Assets/Tests/EditMode/BoardManagerTests/BoardManagerTestBase.cs
+++ b/Assets/Tests/EditMode/BoardManagerTests/BoardManagerTestBase.cs
@@ -17,6 +17,8 @@ namespace Tests.EditMode.BoardManagerTests
             boardManager.boardRenderer = gameObject.AddComponent<BoardRenderer>();
             boardManager.movePlayerChannel = CreateChannel<MovePlayerEventChannel>();
             boardManager.passedGoChannel = CreateChannel<IntEventChannel>();
+            boardManager.playerMovedChannel = CreateChannel<PlayerMovedEventChannel>();
+
             boardManager.movePlayerChannel.Subscribe(boardManager.MovePlayer);
             
             InitializeTestLogger();

--- a/Assets/Tests/EditMode/BoardManagerTests/BoardMovementPathTests.cs
+++ b/Assets/Tests/EditMode/BoardManagerTests/BoardMovementPathTests.cs
@@ -1,0 +1,140 @@
+﻿using NUnit.Framework;
+using PsycheOpoly.Board;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System.Linq;
+
+namespace Tests.EditMode.BoardManagerTests
+{
+    /// <summary>
+    /// US-253 Movement Rules:
+    ///  - PlayerMovedEvent must contain from/to/path
+    ///  - movement must wrap correctly, handle negative steps
+    ///  and raise passedGoChannel when wrapping forward
+    /// </summary>
+    public class BoardMovementPathTests : BoardManagerTestBase
+    {
+        private int lastPassedGoPlayer = -1;
+        private PlayerMovedEvent lastMoveEvent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            boardManager.InitializeBoard(6);
+
+            lastPassedGoPlayer = -1;
+            lastMoveEvent = null;
+
+            boardManager.playerMovedChannel.Subscribe(evt =>
+            {
+                lastMoveEvent = evt;
+            });
+
+            //pass go
+            boardManager.passedGoChannel.Subscribe(pid =>
+            {
+                lastPassedGoPlayer = pid;
+            });
+        }
+
+        [Test]
+        public void MoveForward_NoWrap_ProducesCorrectPath()
+        {
+            boardManager.SetPlayerPosition(1, 2); 
+
+            boardManager.MovePlayer(new MovePlayerEvent(1, 3));
+
+            Assert.AreEqual(5, boardManager.GetPlayerPosition(1), "Final position wrong");
+            Assert.NotNull(lastMoveEvent, "Movement event did not fire");
+
+            CollectionAssert.AreEqual(
+                new[] { 3, 4, 5 },
+                lastMoveEvent.pathIndices,
+                "Path indices incorrect"
+            );
+        }
+        
+        [Test]
+        public void MoveForward_WrapsAroundBoard_ProducesCorrectPath()
+        {
+            boardManager.SetPlayerPosition(1, 5);
+
+            boardManager.MovePlayer(new MovePlayerEvent(1, 3));
+
+            Assert.AreEqual(2, boardManager.GetPlayerPosition(1), "Wrap final position incorrect");
+            Assert.NotNull(lastMoveEvent);
+
+
+
+            CollectionAssert.AreEqual(
+                new[] { 0, 1, 2 },
+                lastMoveEvent.pathIndices,
+                "Wrap path incorrect"
+
+            );
+
+            Assert.AreEqual(1, lastPassedGoPlayer, "PassedGo should fire when wrapping forward");
+        }
+
+        [Test]
+        public void MoveBackward_ProducesCorrectReversePath()
+        {
+            boardManager.SetPlayerPosition(1, 4);
+
+            boardManager.MovePlayer(new MovePlayerEvent(1, -2));
+
+            Assert.AreEqual(2, boardManager.GetPlayerPosition(1));
+            CollectionAssert.AreEqual(
+                new[] { 3, 2 },
+                lastMoveEvent.pathIndices,
+                "Reverse path incorrect"
+            );
+
+            Assert.AreEqual(-1, lastPassedGoPlayer, "Backward moves should NOT trigger passedGo");
+        }
+
+        [Test]
+        public void MoveBackward_WrapsCorrectly()
+        {
+            boardManager.SetPlayerPosition(1, 0);
+
+            boardManager.MovePlayer(new MovePlayerEvent(1, -3));
+
+            Assert.AreEqual(3, boardManager.GetPlayerPosition(1), "Backward wrap incorrect");
+            CollectionAssert.AreEqual(
+                new[] { 5, 4, 3 },
+                lastMoveEvent.pathIndices,
+                "Backward wrap path incorrect"
+            );
+        }
+
+        [Test]
+        public void MoveZero_ProducesEmptyPath()
+        {
+            boardManager.SetPlayerPosition(1, 3);
+
+            boardManager.MovePlayer(new MovePlayerEvent(1, 0));
+
+            Assert.AreEqual(3, boardManager.GetPlayerPosition(1));
+            Assert.NotNull(lastMoveEvent);
+
+            Assert.AreEqual(0, lastMoveEvent.pathIndices.Length, "Path should be empty for 0 movement");
+        }
+
+        [Test]
+        public void PlayerMovedEvent_ContainsCorrectFrom_To_And_Path()
+        {
+            boardManager.SetPlayerPosition(2, 1);
+
+            boardManager.MovePlayer(new MovePlayerEvent(2, 2));
+
+            Assert.AreEqual(1, lastMoveEvent.previousPosition);
+            Assert.AreEqual(3, lastMoveEvent.newPosition);
+            CollectionAssert.AreEqual(
+                new[] { 2, 3 },
+                lastMoveEvent.pathIndices,
+                "Event path incorrect"
+            );
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BoardManagerTests/BoardMovementPathTests.cs.meta
+++ b/Assets/Tests/EditMode/BoardManagerTests/BoardMovementPathTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f23c77bc5669a94c89f6c86b4c162dd

--- a/Assets/Tests/PlayMode/BoardRenderer/BoardRendererTestBase.cs
+++ b/Assets/Tests/PlayMode/BoardRenderer/BoardRendererTestBase.cs
@@ -117,7 +117,7 @@ namespace Tests.PlayMode.BoardRenderer
         /// <returns></returns>
         protected IEnumerator MovePieceAndWait(int playerId, int targetSpace, float waitTime = 2f)
         {
-            boardRenderer.MovePiece(new PlayerMovedEvent(playerId, 0, targetSpace));
+            boardRenderer.MovePiece(new PlayerMovedEvent(playerId, 0, targetSpace, null));
             yield return new WaitForSeconds(waitTime);
         }
     }

--- a/UMLDiagrams/Task280.mmd
+++ b/UMLDiagrams/Task280.mmd
@@ -1,0 +1,26 @@
+stateDiagram-v2
+[*] --> StartTurn
+
+StartTurn --> RollDice : Player triggers RollDiceRequest
+RollDice --> EvaluateRoll : RollDice() / DiceRolledEvent
+
+state EvaluateRoll {
+    [*] --> CheckDoubles
+    CheckDoubles --> TripleDoubles : rolledThreeDoubles
+    CheckDoubles --> NormalRoll : !rolledThreeDoubles
+    TripleDoubles --> SendToJail
+}
+
+SendToJail --> EndTurn : SetPlayerPosition(Jail)
+
+NormalRoll --> MovePiece : CalculateMove()
+MovePiece --> CheckPassedGo : MovePlayer()
+CheckPassedGo --> ResolveTile : landedSpace != Go
+CheckPassedGo --> CollectGo : passedGoChannel
+CollectGo --> ResolveTile
+
+ResolveTile --> RollAgain? : rolledDoubles
+ResolveTile --> EndTurn : !rolledDoubles
+RollAgain? --> RollDice : doublesAllowed
+
+EndTurn --> [*]


### PR DESCRIPTION
11/13: rebase dev is complete after Dakota's US252. Will need to be rebased if US322 if merged first. Just shoot me a message once US322 is merged into dev.

Task 276Implement StandardMovementStrategy

Task 277Emit PlayerMovedEvent with from to path

Task 278Hook into DiceManager and BoardManager

Task 279Create tests for crossing start, doubles or no doubles, and chance tile
Task 280Create activity diagram for Roll to move to resolve logic