### PR TITLE
Hotfix- fixes broken 322 tests

### DIFF
--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -126,8 +126,15 @@ public class Player : ScriptableObject
         return doublesInRow; 
     }
 
-    public void AddOwnedProperty(OwnableSpaceData ownableSpace) { }
-    public void RemoveOwnedProperty(OwnableSpaceData ownableSpace) { }
+    public void AddOwnedProperty(OwnableSpaceData ownableSpace)
+    {
+        ownedProperties.Add(ownableSpace);
+    }
+
+    public void RemoveOwnedProperty(OwnableSpaceData ownableSpace)
+    {
+        ownedProperties.Remove(ownableSpace);
+    }
     public List<OwnableSpaceData> GetOwnedProperties() 
     { 
         return ownedProperties; 

--- a/Assets/Scripts/Data/SpaceData/LaunchPadSpaceData.cs
+++ b/Assets/Scripts/Data/SpaceData/LaunchPadSpaceData.cs
@@ -46,8 +46,11 @@ public class LaunchPadSpaceData : SpaceData
     // for testing
     public void EnsureSubscribed()
     {
-        OnDisable();
-        OnEnable();
+        playerGoesToJailEventChannel?.Unsubscribe(AddPlayerToJail);
+        playerLeavesJailEventChannel?.Unsubscribe(RemovePlayerFromJail);
+        
+        playerGoesToJailEventChannel?.Subscribe(AddPlayerToJail);
+        playerLeavesJailEventChannel?.Subscribe(RemovePlayerFromJail);
     }
 
     private void OnEnable()

--- a/Assets/Tests/EditMode/SpaceDataTests/InstrumentSpaceDataTests.cs
+++ b/Assets/Tests/EditMode/SpaceDataTests/InstrumentSpaceDataTests.cs
@@ -48,11 +48,13 @@ namespace Tests.EditMode.SpaceDataTests
             
             for (int i = 0; i < space.researchFundingLevels.Length; i++)
             {
+                payload = null; 
+                
                 space.OnLanded(player);
                 
-                Assert.NotNull(payload);
-                Assert.Equals(100 + (50 * i), payload.amount);
-                Assert.Equals(space, payload.sourceSpace);
+                Assert.NotNull(payload, $"payload was null on iteration {i}");
+                Assert.AreEqual(100 + (50 * i), payload.amount);
+                Assert.AreEqual(space, payload.sourceSpace);
                 
                 owner.AddOwnedProperty(
                     ScriptableObject.CreateInstance<InstrumentSpaceData>());

--- a/Assets/Tests/EditMode/SpaceDataTests/LaunchPadSpaceDataTests.cs
+++ b/Assets/Tests/EditMode/SpaceDataTests/LaunchPadSpaceDataTests.cs
@@ -47,13 +47,14 @@ namespace Tests.EditMode.SpaceDataTests
         [Test]
         public void PlayerAddedAndRemovedFromJail()
         {
-            playerGoToJailChannel.RaiseEvent(
-                ScriptableObject.CreateInstance<Player>());
-            Assert.Equals(lpsd.playersInJail.Count, 1);
+            Player p = ScriptableObject.CreateInstance<Player>();
+            playerGoToJailChannel.RaiseEvent(p);
             
-            playerLeaveJailChannel.RaiseEvent(
-                ScriptableObject.CreateInstance<Player>());
-            Assert.Equals(lpsd.playersInJail.Count, 0);
+            Assert.AreEqual(lpsd.playersInJail.Count, 1);
+            
+            playerLeaveJailChannel.RaiseEvent(p);
+            
+            Assert.AreEqual(lpsd.playersInJail.Count, 0);
         }
     }
 }

--- a/Assets/Tests/EditMode/SpaceDataTests/OwnableSpaceDataTests.cs
+++ b/Assets/Tests/EditMode/SpaceDataTests/OwnableSpaceDataTests.cs
@@ -39,7 +39,7 @@ namespace Tests.EditMode.SpaceDataTests
             space.OnLanded(ScriptableObject.CreateInstance<Player>());
             
             Assert.NotNull(payload);
-            Assert.Equals(100, payload.cost);
+            Assert.AreEqual(100, payload.cost);
         }
     }
 }

--- a/Assets/Tests/EditMode/SpaceDataTests/PlanetSpaceDataTests.cs
+++ b/Assets/Tests/EditMode/SpaceDataTests/PlanetSpaceDataTests.cs
@@ -51,18 +51,20 @@ namespace Tests.EditMode.SpaceDataTests
             space.chargeOwnershipFeeEventChannel.Subscribe(Listener);
             drec.RaiseEvent(new DiceRolledEvent(3,3,6));
 
-            Assert.Equals(6, space.lastDiceRoll);
+            Assert.AreEqual(6, space.lastDiceRoll);
             
             space.OnLanded(player);
             
             Assert.NotNull(payload);
-            Assert.Equals(6 * 3, payload.amount);
+            Assert.AreEqual(6 * 3, payload.amount);
             
             owner.AddOwnedProperty(
                 ScriptableObject.CreateInstance<PlanetSpaceData>());
             
+            space.OnLanded(player);
+            
             Assert.NotNull(payload);
-            Assert.Equals(6 * 5, payload.amount);
+            Assert.AreEqual(6 * 5, payload.amount);
         }
     }
 }

--- a/Assets/Tests/EditMode/SpaceDataTests/PropertySpaceDataTests.cs
+++ b/Assets/Tests/EditMode/SpaceDataTests/PropertySpaceDataTests.cs
@@ -51,10 +51,10 @@ namespace Tests.EditMode.SpaceDataTests
                 space.OnLanded(player);
                 
                 Assert.NotNull(payload);
-                Assert.Equals(100 + 50 * i, payload.amount);
-                Assert.Equals(owner, payload.toPlayer);
-                Assert.Equals(player, payload.fromPlayer);
-                Assert.Equals(space, payload.sourceSpace);
+                Assert.AreEqual(100 + 50 * i, payload.amount);
+                Assert.AreEqual(owner, payload.toPlayer);
+                Assert.AreEqual(player, payload.fromPlayer);
+                Assert.AreEqual(space, payload.sourceSpace);
                 
                 space.UpgradeProperty();
             }


### PR DESCRIPTION
I goofed and forgot to check my tests to see if they're working before PR. News flash, they weren't. Got that sorted now.

Pro tip- `Assert.Equals()` != `Assert.IsEqual()`.