### PR TITLE
US258 As a player, I want banners or prompts to reflect the rules in real time, so the game flow is clear.

### DIFF
--- a/Assets/Prefabs/HUD/TurnBannerCanvas.prefab
+++ b/Assets/Prefabs/HUD/TurnBannerCanvas.prefab
@@ -214,11 +214,11 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 25
+  m_VertexColorAlwaysGammaSpace: 1
+  m_AdditionalShaderChannelsFlag: 0
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 2
   m_TargetDisplay: 0
 --- !u!114 &6342595688924856529
 MonoBehaviour:
@@ -232,10 +232,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3

--- a/Assets/Prefabs/HUD/TurnBannerCanvas.prefab
+++ b/Assets/Prefabs/HUD/TurnBannerCanvas.prefab
@@ -420,12 +420,30 @@ MonoBehaviour:
   turnLabel: {fileID: 2649314433219123149}
   continueButton: {fileID: 5843930613950888418}
   canvasGroup: {fileID: 8185259267116603201}
-  turnStartedChannel: {fileID: 0}
-  fadeDuration: 0.25
-  slideOffset: 60
+  turnStartedChannel: {fileID: 11400000, guid: 83cdc6259df024842a7aff913879d540, type: 2}
+  fadeDuration: 1
+  slideOffset: 180
   ease:
     serializedVersion: 2
-    m_Curve: []
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -138,10 +138,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 327057945443998030, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
-      propertyPath: turnStartedChannel
-      value: 
-      objectReference: {fileID: 11400000, guid: 83cdc6259df024842a7aff913879d540, type: 2}
     - target: {fileID: 913164210820008243, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
       propertyPath: m_FontData.m_BestFit
       value: 1

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -274,10 +274,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5051379046939290862, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
-      propertyPath: m_SortingOrder
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 5579961459612620425, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
       propertyPath: m_Name
       value: TurnBannerCanvas
@@ -285,18 +281,6 @@ PrefabInstance:
     - target: {fileID: 5579961459612620425, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
       propertyPath: m_IsActive
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6342595688924856529, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
-      propertyPath: m_UiScaleMode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6342595688924856529, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
-      propertyPath: m_ReferenceResolution.x
-      value: 1920
-      objectReference: {fileID: 0}
-    - target: {fileID: 6342595688924856529, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
-      propertyPath: m_ReferenceResolution.y
-      value: 1080
       objectReference: {fileID: 0}
     - target: {fileID: 6623243013815439069, guid: b55a24a7347066947bfcdd0f17b8c131, type: 3}
       propertyPath: m_SizeDelta.x

--- a/Assets/Scripts/UI/TurnBannerController.cs
+++ b/Assets/Scripts/UI/TurnBannerController.cs
@@ -41,8 +41,6 @@ public class TurnBannerController : MonoBehaviour
         canvasGroup.interactable = false;
         canvasGroup.blocksRaycasts = false;
         rect.anchoredPosition = hiddenPos;
-
-        //gameObject.SetActive(false);
     }
 
     private void OnEnable()
@@ -94,6 +92,7 @@ public class TurnBannerController : MonoBehaviour
 
     private IEnumerator FadeSlide(bool show)
     {
+        // for editmode tests, skip the animation and set to end state
         if (!Application.isPlaying)
         {
             float targetAlpha = show ? 1f : 0f;
@@ -117,15 +116,6 @@ public class TurnBannerController : MonoBehaviour
         Vector2 startPos = rect.anchoredPosition;
         Vector2 endPos = show ? shownPos : hiddenPos;
 
-        if (show && !gameObject.activeSelf)
-        {
-            gameObject.SetActive(true);
-            canvasGroup.alpha = 0;
-            rect.anchoredPosition = hiddenPos;
-            startA = 0;
-            startPos = hiddenPos;
-        }
-
         canvasGroup.blocksRaycasts = true;
         canvasGroup.interactable = false;
 
@@ -135,7 +125,7 @@ public class TurnBannerController : MonoBehaviour
             float t = ease.Evaluate(time / duration);
             canvasGroup.alpha = Mathf.Lerp(startA, endA, t);
             rect.anchoredPosition = Vector2.Lerp(startPos, endPos, t);
-            yield return null;
+            yield return new WaitForEndOfFrame(); // this ensures that this is updated per frame
         }
 
         canvasGroup.alpha = endA;
@@ -150,8 +140,7 @@ public class TurnBannerController : MonoBehaviour
     {
         if (turnLabel != null)
             turnLabel.text = $"Player {playerId}'s Turn";
-
-        gameObject.SetActive(true);
+        
         PlayAnim(true);
     }
 
@@ -160,8 +149,7 @@ public class TurnBannerController : MonoBehaviour
     {
         if (turnLabel != null)
             turnLabel.text = $"Turn {turnNum} — Player {playerId}";
-
-        gameObject.SetActive(true);
+        
         PlayAnim(true);
     }
 

--- a/Assets/Tests/EditMode/EventsTests/TurnBannerControllerTests.cs
+++ b/Assets/Tests/EditMode/EventsTests/TurnBannerControllerTests.cs
@@ -51,5 +51,33 @@ namespace Tests.EditMode.EventsTests
             Assert.IsTrue(cg.interactable);
             Assert.AreEqual(cg.alpha, 1f);
         }
+
+        [Test]
+        public void EditMode_OnEnableSubscribes()
+        {
+            controller.Hide();
+            controller.gameObject.SetActive(false);
+            controller.gameObject.SetActive(true);
+            turnStartedEventChannel.RaiseEvent(new TurnStartedEvent(0,0));
+            Assert.IsTrue(cg.interactable);
+            Assert.AreEqual(cg.alpha, 1f);
+        }
+
+        [Test]
+        public void EditMode_OnDisableUnsubscribes()
+        {
+            controller.Hide();
+            
+            // simulate firing OnDisable, because EditMode won't fire these methods
+            var onDisable = controller.GetType().GetMethod("OnDisable",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            onDisable?.Invoke(controller, null);
+            
+            Assert.IsFalse(controller.IsSubscribed);
+            
+            turnStartedEventChannel.RaiseEvent(new TurnStartedEvent(0,0));
+            Assert.IsFalse(cg.interactable);
+            Assert.AreEqual(cg.alpha, 0f);
+        }
     }
 }

--- a/Assets/Tests/EditMode/EventsTests/TurnBannerControllerTests.cs
+++ b/Assets/Tests/EditMode/EventsTests/TurnBannerControllerTests.cs
@@ -41,5 +41,15 @@ namespace Tests.EditMode.EventsTests
             Assert.IsTrue(controller.gameObject.activeSelf, "Banner should be active after ShowBanner(2).");
             StringAssert.Contains("Player 2", turnLabel.text);
         }
+
+        [Test]
+        public void EditMode_EventsHandledWhileHidden()
+        {
+            controller.Hide();
+            turnStartedEventChannel.RaiseEvent(new TurnStartedEvent(0,0));
+            
+            Assert.IsTrue(cg.interactable);
+            Assert.AreEqual(cg.alpha, 1f);
+        }
     }
 }

--- a/Assets/Tests/EditMode/EventsTests/TurnBannerTestBase.cs
+++ b/Assets/Tests/EditMode/EventsTests/TurnBannerTestBase.cs
@@ -26,6 +26,8 @@ namespace Tests.EditMode.EventsTests
         protected GameObject buttonGO;
         protected Button continueButton;
 
+        protected TurnStartedEventChannel turnStartedEventChannel;
+
         /// <summary>Creates a canvas so UI components can work in EditMode.</summary>
         protected virtual void CreateCanvas()
         {
@@ -93,6 +95,8 @@ namespace Tests.EditMode.EventsTests
 
             continueButton = buttonGO.GetComponent<Button>();
 
+            turnStartedEventChannel = ScriptableObject.CreateInstance<TurnStartedEventChannel>();
+
             //Wire refs to controller
             controller.GetType().GetField("turnLabel",
                 System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
@@ -105,6 +109,10 @@ namespace Tests.EditMode.EventsTests
             controller.GetType().GetField("canvasGroup",
                 System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
                 ?.SetValue(controller, cg);
+            
+            controller.GetType().GetField("turnStartedChannel",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                ?.SetValue(controller, turnStartedEventChannel);
 
             //Manually simulate Awake() because they will not fire in EditMode testing 
             var awake = controller.GetType().GetMethod("Awake",

--- a/Documentation/UI_Diagrams/TurnBannerController-Sequence.mmd
+++ b/Documentation/UI_Diagrams/TurnBannerController-Sequence.mmd
@@ -1,0 +1,16 @@
+sequenceDiagram
+    participant GM as GameManager
+    participant EC as TurnStartedEventChannel
+    participant TBC as TurnBannerController
+    participant User as User
+
+    Note over TBC: OnEnable: Subscribe to TurnStartedEvent
+
+    GM->>EC: Raise(TurnStartedEvent)
+    EC->>TBC: OnTurnStarted(payload)
+    TBC->>TBC: Update label, Show()
+
+    User->>TBC: Click Continue
+    TBC->>TBC: Hide()
+
+    Note over TBC: OnDisable: Unsubscribe from TurnStartedEvent


### PR DESCRIPTION
Confirms refactor of `TurnBannerController` to use the CanvasGroup instead of toggling `active` state, which keeps it responsive to events while not being visible/interactable when not in use.

Adds tests to ensure that subscription/unsubscription happens correctly in the `OnEnable` and `OnDisable` event hooks from the engine, and that it responds properly to events in the correct way.

Adds a sequence diagram showing the event path, which can be iterated on if we decide to expand this UI element to cover more behaviour than just turn changes.