### PR TITLE
US402 As a player, I want rent and tile effects to update correctly under all rules strategies so that they properly interact and it feels consistent with Monoploy rules

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -29,6 +29,8 @@ public class GameManager : MonoBehaviour
     [SerializeField] private DiceManager diceManager;
     [SerializeField] private BoardManager boardManager;
     [SerializeField] private StandardMovementStrategy movementStrategy;
+    [SerializeField] private RulesManager rulesManager;
+
 
 
     private int playerCount = 0;

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Logging;
 using PsycheOpoly.Board;
 using Assets.Scripts.Managers.Movement;
+using Assets.Scripts.Managers;
 
 public class GameManager : MonoBehaviour
 {

--- a/Assets/Scripts/Managers/Rent/IRentStrategy.cs
+++ b/Assets/Scripts/Managers/Rent/IRentStrategy.cs
@@ -1,3 +1,6 @@
+using Assets.Scripts.Managers.Rules;
+
+
 namespace Assets.Scripts.Managers.Rent
 {
     public interface IRentStrategy

--- a/Assets/Scripts/Managers/Rent/Primitives.cs
+++ b/Assets/Scripts/Managers/Rent/Primitives.cs
@@ -16,15 +16,6 @@ namespace Assets.Scripts.Managers.Rent
         int[] RentByHouses { get; }   
     }
 
-    /// <summary>Rules/constants centralized to keep StandardRentStrategy clean.</summary>
-    public interface IRuleSet
-    {
-        int RailroadBaseRent();       //usually 25 in game
-        int UtilityRentSingleMult();  //usually 4 in game
-        int UtilityRentBothMult();    //usually 10 in game
-        int StreetsInGroup(ColorGroup g); //total street amount in a color set
-    }
-
     /// <summary>Ownership lookups kept external to Strategy.</summary>
     public interface IOwnershipService
     {

--- a/Assets/Scripts/Managers/Rent/RentManager.cs
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs
@@ -14,6 +14,8 @@ namespace Assets.Scripts.Managers.Rent
         [SerializeField] private EconomyAdapter economy;                     //money mover (placeholder)
         [SerializeField] private OwnershipServiceAdapter ownership;          //ownership source of truth (adapter)
         [SerializeField] private RulesManager rulesManager;
+        [SerializeField] private RentModifierService rentModifiers;
+
 
         private IRuleSet rules;
         private IRentStrategy strategy = new StandardRentStrategy();
@@ -37,7 +39,14 @@ namespace Assets.Scripts.Managers.Rent
             var owner = ownership.GetOwner(tile);
             if (owner == null || owner == tenant) return;
 
-            int rent = strategy.ComputeRent(tile, owner, diceTotal, ownership, rules);
+            //replacing basic rent to use modifiers
+            int baseRent = strategy.ComputeRent(tile, owner, diceTotal, ownership, rules);
+            int rent = rentModifiers != null ? rentModifiers.ApplyAll(baseRent, tile, tenant, owner) : baseRent;
+
+            Logging.Logger.Debug("RentManager.TryChargeRent",
+                $"BaseRent={baseRent} FinalRent={rent} Tenant={tenant?.GetId()} Owner={owner?.GetId()} Tile={tile?.Name}",
+                Logging.LogCategory.Gameplay);
+
             if (rent <= 0) return;
 
             bool ok = economy.Transfer(tenant, owner, rent);
@@ -46,6 +55,9 @@ namespace Assets.Scripts.Managers.Rent
         //Make sure serialized dependencies are not null
         private void EnsureDependencies()
         {
+            if (!rentModifiers)
+                rentModifiers = GetComponent<RentModifierService>() ?? gameObject.AddComponent<RentModifierService>();
+
             if (!economy)
                 economy = GetComponent<EconomyAdapter>() ?? gameObject.AddComponent<EconomyAdapter>();
 

--- a/Assets/Scripts/Managers/Rent/RentManager.cs
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using Assets.Scripts.Managers.Rent;
+
 
 namespace Assets.Scripts.Managers.Rent
 {
@@ -14,6 +16,7 @@ namespace Assets.Scripts.Managers.Rent
         [SerializeField] private RuleSet rules = new RuleSet();              //rule constants
 
         private IRentStrategy strategy = new StandardRentStrategy();
+        public IOwnershipService Ownership => ownership;
 
         private void Awake()
         {
@@ -51,6 +54,25 @@ namespace Assets.Scripts.Managers.Rent
             if (rules == null)
                 rules = new RuleSet();
         }
+
+        //helpers
+        public void SetOwner(ITileRentInfo tile, Player owner)
+        {
+            EnsureDependencies();
+            ownership.SetOwner(tile, owner);
+        }
+
+        public int CountOwnedInGroup(Player owner, ColorGroup group)
+        {
+            EnsureDependencies();
+            return ownership.CountOwnedInGroup(owner, group);
+        }
+
+        public int CountRailroadsOwned(Player owner)
+        {
+            EnsureDependencies();
+            return ownership.CountRailroadsOwned(owner);
+        }
     }
 
     //Money mover. Replace with your real EconomyManager later.
@@ -72,6 +94,8 @@ namespace Assets.Scripts.Managers.Rent
             return true;
         }
     }
+
+
 
     //Rule constants for standard Monopoly rent. can be converted to ScriptableObject
     [System.Serializable]

--- a/Assets/Scripts/Managers/Rent/RentManager.cs
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using Assets.Scripts.Managers.Rent;
+using Assets.Scripts.Managers.Rules;
 
 
 namespace Assets.Scripts.Managers.Rent
@@ -13,8 +13,9 @@ namespace Assets.Scripts.Managers.Rent
         [SerializeField] private PlayerManager playerManager;                //not used by rent calc yet
         [SerializeField] private EconomyAdapter economy;                     //money mover (placeholder)
         [SerializeField] private OwnershipServiceAdapter ownership;          //ownership source of truth (adapter)
-        [SerializeField] private RuleSet rules = new RuleSet();              //rule constants
+        [SerializeField] private RulesManager rulesManager;
 
+        private IRuleSet rules;
         private IRentStrategy strategy = new StandardRentStrategy();
         public IOwnershipService Ownership => ownership;
 
@@ -51,8 +52,11 @@ namespace Assets.Scripts.Managers.Rent
             if (!ownership)
                 ownership = GetComponent<OwnershipServiceAdapter>() ?? gameObject.AddComponent<OwnershipServiceAdapter>();
 
-            if (rules == null)
-                rules = new RuleSet();
+            if (!rulesManager)
+                rulesManager = FindObjectOfType<RulesManager>();
+
+            if (rules == null && rulesManager != null)
+                rules = rulesManager.GetRuleSet();
         }
 
         //helpers
@@ -93,34 +97,5 @@ namespace Assets.Scripts.Managers.Rent
             to.SetMoney(to.GetMoney() + amount);
             return true;
         }
-    }
-
-
-
-    //Rule constants for standard Monopoly rent. can be converted to ScriptableObject
-    [System.Serializable]
-    public class RuleSet : IRuleSet
-    {
-        [Tooltip("Base rent for 1 owned railroad (25, 50, 100, 200 scaling).")]
-        public int RailroadBase = 25;
-
-        [Tooltip("Utility multiplier when owner has a single utility.")]
-        public int UtilitySingle = 4;
-
-        [Tooltip("Utility multiplier when owner has both utilities.")]
-        public int UtilityBoth = 10;
-
-        public int RailroadBaseRent() => RailroadBase;
-        public int UtilityRentSingleMult() => UtilitySingle;
-        public int UtilityRentBothMult() => UtilityBoth;
-
-        //Default Monopoly set sizes
-        public int StreetsInGroup(ColorGroup g) =>
-            g switch
-            {
-                ColorGroup.Brown or ColorGroup.DarkBlue => 2,
-                ColorGroup.LightBlue or ColorGroup.Pink or ColorGroup.Orange or ColorGroup.Red or ColorGroup.Yellow or ColorGroup.Green => 3,
-                _ => 0
-            };
     }
 }

--- a/Assets/Scripts/Managers/Rent/RentManager.cs
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs
@@ -79,8 +79,10 @@ namespace Assets.Scripts.Managers.Rent
             if (!rulesManager)
                 rulesManager = FindObjectOfType<RulesManager>();
 
-            if (rules == null && rulesManager != null)
-                rules = rulesManager.GetRuleSet();
+            if (rules == null)
+                rules = rulesManager != null
+                    ? rulesManager.GetRuleSet()
+                    : new StandardRuleSet();
         }
 
         //helpers

--- a/Assets/Scripts/Managers/Rent/RentManager.cs
+++ b/Assets/Scripts/Managers/Rent/RentManager.cs
@@ -16,6 +16,9 @@ namespace Assets.Scripts.Managers.Rent
         [SerializeField] private RulesManager rulesManager;
         [SerializeField] private RentModifierService rentModifiers;
 
+        [Header("Events")]
+        [SerializeField] private IntEventChannel rentComputedChannel;
+
 
         private IRuleSet rules;
         private IRentStrategy strategy = new StandardRentStrategy();
@@ -35,6 +38,13 @@ namespace Assets.Scripts.Managers.Rent
             if (tenant == null || tile == null) return;
 
             EnsureDependencies();
+            
+            //pre-check
+            if (rules == null)
+            {
+                Logging.Logger.Warn("RentManager", "Rules not initialized; using zero rent.");
+                return;
+            }
 
             var owner = ownership.GetOwner(tile);
             if (owner == null || owner == tenant) return;
@@ -46,6 +56,8 @@ namespace Assets.Scripts.Managers.Rent
             Logging.Logger.Debug("RentManager.TryChargeRent",
                 $"BaseRent={baseRent} FinalRent={rent} Tenant={tenant?.GetId()} Owner={owner?.GetId()} Tile={tile?.Name}",
                 Logging.LogCategory.Gameplay);
+            rentComputedChannel?.RaiseEvent(rent);
+
 
             if (rent <= 0) return;
 

--- a/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
+++ b/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine;
 using Logging;
+using Assets.Scripts.Managers.Rules;
 
 namespace Assets.Scripts.Managers.Rent
 {

--- a/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
+++ b/Assets/Scripts/Managers/Rent/StandardRentStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using Logging;
 
 namespace Assets.Scripts.Managers.Rent
 {
@@ -30,33 +31,68 @@ namespace Assets.Scripts.Managers.Rent
 
             //Houses and hotels table if needed will be checked first
             //Completes task 283
+            //edited for task403
             if (houses > 0 && tile.RentByHouses != null && tile.RentByHouses.Length > houses)
             {
-                return tile.RentByHouses[houses];
+                int rent = tile.RentByHouses[houses];
+
+                Logging.Logger.Debug("RentStrategy.Street",
+                    $"[{tile.Name}] HouseCount={houses} Rent={rent}",
+                    LogCategory.Gameplay);
+
+                return rent;
             }
 
             //If there are no houses check monoploy which doubles base rent
-            bool hasMonopoly = own.CountOwnedInGroup(owner, tile.Group) >= rules.StreetsInGroup(tile.Group);
-            return hasMonopoly ? tile.BaseRent * 2 : tile.BaseRent;
+            bool hasMonopoly =
+               own.CountOwnedInGroup(owner, tile.Group) >= rules.StreetsInGroup(tile.Group);
+
+            int finalRent = hasMonopoly ? tile.BaseRent * 2 : tile.BaseRent;
+
+            Logging.Logger.Debug("RentStrategy.Street",
+                $"[{tile.Name}] Houses=0 BaseRent={tile.BaseRent} Monopoly={hasMonopoly} Final={finalRent}",
+                LogCategory.Gameplay);
+
+            return finalRent;
+
+
         }
 
         private int RailroadRent(Player owner, IOwnershipService own, IRuleSet rules)
         {
-            int n = Mathf.Clamp(own.CountRailroadsOwned(owner), 0, 4);
-            if (n <= 0) return 0;
+            int count = Mathf.Clamp(own.CountRailroadsOwned(owner), 0, 4);
+            if (count <= 0) return 0;
 
-            //Doubles based on how many owned
             int baseRent = rules.RailroadBaseRent();
-            int rent = baseRent << (n - 1);
+
+            int rent = baseRent << (count - 1);
+
+            Logging.Logger.Debug("RentStrategy.Railroad",
+                $"RailroadsOwned={count} BaseRent={baseRent} Final={rent}",
+                LogCategory.Gameplay);
+
             return rent;
         }
 
         private int UtilityRent(Player owner, int diceTotal, IOwnershipService own, IRuleSet rules)
         {
-            if (diceTotal < 0) diceTotal = 0;
+            int total = Mathf.Max(0, diceTotal);
             bool ownsBoth = own.OwnsBothUtilities(owner);
-            int mult = ownsBoth ? rules.UtilityRentBothMult() : rules.UtilityRentSingleMult();
-            return diceTotal * mult; 
+
+
+            int mult = ownsBoth ?
+                rules.UtilityRentBothMult() :
+                rules.UtilityRentSingleMult();
+
+            int rent = total * mult;
+
+            Logging.Logger.Debug("RentStrategy.Utility",
+                $"Dice={total} OwnsBoth={ownsBoth} Mult={mult} Final={rent}",
+                LogCategory.Gameplay);
+
+            return rent;
+
+
         }
 
     }

--- a/Assets/Scripts/Managers/Rules.meta
+++ b/Assets/Scripts/Managers/Rules.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 989f3e0c4d249534bb8bd3ef2e2fa234
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/Rules/IRentModifiers.cs
+++ b/Assets/Scripts/Managers/Rules/IRentModifiers.cs
@@ -1,0 +1,16 @@
+﻿using Assets.Scripts.Managers.Rent;
+
+namespace Assets.Scripts.Managers.Rent
+{
+    /// <summary>Rent modification contract applied after base rent is computed.</summary>
+    /// this basically will act as the rent modification ruleset
+    //US402-T406
+    public interface IRentModifier
+    {
+        /// <summary>return modified rent given the current context.</summary>
+        int Apply(int currentRent, ITileRentInfo tile, Player tenant, Player owner);
+
+        /// <summary>if this modifier still applies; if false it will be removed.</summary>
+        bool IsActive();
+    }
+}

--- a/Assets/Scripts/Managers/Rules/IRentModifiers.cs.meta
+++ b/Assets/Scripts/Managers/Rules/IRentModifiers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d9cca8a8c30d284399866b847206aaa

--- a/Assets/Scripts/Managers/Rules/IRuleSet.cs
+++ b/Assets/Scripts/Managers/Rules/IRuleSet.cs
@@ -3,9 +3,14 @@ using UnityEngine;
 
 namespace Assets.Scripts.Managers.Rules
 {
+    /// <summary>
+    /// interface for rule sets used by rent strategy 
+    /// and later tile effects
+    /// **placeholder for architecture setup in US402-T404**
+    /// </summary>
     public interface IRuleSet
     {
-        //just a placeholder while i build out the concept of the architecture
+        // still a placeholder just adding the summary
     }
 }
 

--- a/Assets/Scripts/Managers/Rules/IRuleSet.cs
+++ b/Assets/Scripts/Managers/Rules/IRuleSet.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+
+namespace Assets.Scripts.Managers.Rules
+{
+    public interface IRuleSet
+    {
+        //just a placeholder while i build out the concept of the architecture
+    }
+}
+

--- a/Assets/Scripts/Managers/Rules/IRuleSet.cs
+++ b/Assets/Scripts/Managers/Rules/IRuleSet.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Assets.Scripts.Managers.Rent;
 
 
 namespace Assets.Scripts.Managers.Rules
@@ -10,7 +11,10 @@ namespace Assets.Scripts.Managers.Rules
     /// </summary>
     public interface IRuleSet
     {
-        // still a placeholder just adding the summary
+        int RailroadBaseRent();
+        int UtilityRentSingleMult();
+        int UtilityRentBothMult();
+        int StreetsInGroup(ColorGroup group);
     }
 }
 

--- a/Assets/Scripts/Managers/Rules/IRuleSet.cs.meta
+++ b/Assets/Scripts/Managers/Rules/IRuleSet.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 894baa1bcd9398d4e8a2583fb626911e

--- a/Assets/Scripts/Managers/Rules/RentModifierService.cs
+++ b/Assets/Scripts/Managers/Rules/RentModifierService.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using Assets.Scripts.Managers.Rent;
+
+namespace Assets.Scripts.Managers.Rent
+{
+    /// <summary>holds and uses rent modifiers (from cards/tile effects).</summary>
+    public class RentModifierService : MonoBehaviour
+    {
+        private readonly List<IRentModifier> _mods = new ();
+
+        public void Add(IRentModifier mod)
+        {
+            if (mod != null) _mods.Add(mod);
+        }
+
+        //applies all active modifiers and removes expired (non-in use ones)
+        public int ApplyAll(int baseRent, ITileRentInfo tile, Player tenant, Player owner)
+        {
+            int rent = baseRent;
+
+            for (int i = _mods.Count - 1; i >= 0; i--)
+            {
+                var m = _mods[i];
+                if (!m.IsActive())
+                {
+                    _mods.RemoveAt(i);
+                    continue;
+                }
+
+                rent = Mathf.Max(0, m.Apply(rent, tile, tenant, owner));
+            }
+
+            return rent;
+        }
+
+        //a lot of these are general use case helpers for future rule implementaiton
+        //they're also intentionally built out kind of small for simplicities sake /scalability
+        public void DoubleRentOnceForTile(ITileRentInfo targetTile)
+            => Add(new DoubleOnceForTile(targetTile));
+
+        public void FreeNextRentForTenant(Player tenant)
+            => Add(new FreeOnceForTenant(tenant));
+
+
+        private class DoubleOnceForTile : IRentModifier
+        {
+            private readonly ITileRentInfo _tile;
+            private bool _used;
+            public DoubleOnceForTile(ITileRentInfo tile) { _tile = tile; }
+            public int Apply(int current, ITileRentInfo tile, Player tenant, Player owner)
+            {
+                if (_used || _tile == null || tile == null || !ReferenceEquals(tile, _tile)) return current;
+                _used = true;
+                return current * 2;
+            }
+            public bool IsActive() => !_used;
+        }
+
+        private class FreeOnceForTenant : IRentModifier
+        {
+            private readonly Player _tenant;
+            private bool _used;
+            public FreeOnceForTenant(Player t) { _tenant = t; }
+            public int Apply(int current, ITileRentInfo tile, Player tenant, Player owner)
+            {
+                if (_used || tenant == null || _tenant == null || !ReferenceEquals(tenant, _tenant)) return current;
+                _used = true;
+                return 0;
+            }
+            public bool IsActive() => !_used;
+        }
+    }
+}

--- a/Assets/Scripts/Managers/Rules/RentModifierService.cs.meta
+++ b/Assets/Scripts/Managers/Rules/RentModifierService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2d434661098192d48b87ce99073529c8

--- a/Assets/Scripts/Managers/Rules/StandardRuleSet.cs
+++ b/Assets/Scripts/Managers/Rules/StandardRuleSet.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Assets.Scripts.Managers.Rules
+{
+    public class StandardRuleSet : IRuleSet
+    {
+        //also again just a placeholder while i build the concept arch
+    }
+}

--- a/Assets/Scripts/Managers/Rules/StandardRuleSet.cs
+++ b/Assets/Scripts/Managers/Rules/StandardRuleSet.cs
@@ -2,6 +2,10 @@ using UnityEngine;
 
 namespace Assets.Scripts.Managers.Rules
 {
+    /// <summary>
+    /// basic Monopoly rule implementation still an empty placeholder for US402-T404
+    /// Will be populated when rent rule logic is brought oever
+    /// </summary>
     public class StandardRuleSet : IRuleSet
     {
         //also again just a placeholder while i build the concept arch

--- a/Assets/Scripts/Managers/Rules/StandardRuleSet.cs
+++ b/Assets/Scripts/Managers/Rules/StandardRuleSet.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Assets.Scripts.Managers.Rent;
 
 namespace Assets.Scripts.Managers.Rules
 {
@@ -6,8 +7,28 @@ namespace Assets.Scripts.Managers.Rules
     /// basic Monopoly rule implementation still an empty placeholder for US402-T404
     /// Will be populated when rent rule logic is brought oever
     /// </summary>
+    [System.Serializable]
     public class StandardRuleSet : IRuleSet
     {
-        //also again just a placeholder while i build the concept arch
-    }
+        [Tooltip("Base rent for 1 owned railroad (25, 50, 100, 200 scaling).")]
+        [SerializeField] private int railroadBase = 25;
+
+        [Tooltip("Utility multiplier when owner has a single utility.")]
+        [SerializeField] private int utilitySingle = 4;
+
+        [Tooltip("Utility multiplier when owner has both utilities.")]
+        [SerializeField] private int utilityBoth = 10;
+
+        public int RailroadBaseRent() => railroadBase;
+        public int UtilityRentSingleMult() => utilitySingle;
+        public int UtilityRentBothMult() => utilityBoth;
+
+        public int StreetsInGroup(ColorGroup g) =>
+            g switch
+            {
+                ColorGroup.Brown or ColorGroup.DarkBlue => 2,
+                ColorGroup.LightBlue or ColorGroup.Pink or ColorGroup.Orange or ColorGroup.Red or ColorGroup.Yellow or ColorGroup.Green => 3,
+                _ => 0
+            };
+}
 }

--- a/Assets/Scripts/Managers/Rules/StandardRuleSet.cs.meta
+++ b/Assets/Scripts/Managers/Rules/StandardRuleSet.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3219ed5c9d1612447976f4191eb0f8e9

--- a/Assets/Scripts/Managers/RulesManager.cs
+++ b/Assets/Scripts/Managers/RulesManager.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace Assets.Scripts.Managers
+{
+    public class RulesManager : MonoBehaviour
+    {
+        //nothing yet, building architectuer
+    }
+}
+

--- a/Assets/Scripts/Managers/RulesManager.cs
+++ b/Assets/Scripts/Managers/RulesManager.cs
@@ -1,10 +1,22 @@
 using UnityEngine;
+using Assets.Scripts.Managers.Rules;
 
 namespace Assets.Scripts.Managers
 {
+    /// <summary>
+    /// keeps a ref to the active ruleset for now
+    /// this is mostly still just a placeholder for a future task
+    /// </summary>
     public class RulesManager : MonoBehaviour
     {
-        //nothing yet, building architectuer
+        [SerializeField] private StandardRuleSet standardRuleSet = new StandardRuleSet();
+
+        // Currently always returns standard rules.
+        // Later tasks may add alternate rule sets.
+        public IRuleSet GetRuleSet()
+        {
+            return standardRuleSet;
+        }
     }
 }
 

--- a/Assets/Scripts/Managers/RulesManager.cs
+++ b/Assets/Scripts/Managers/RulesManager.cs
@@ -19,4 +19,3 @@ namespace Assets.Scripts.Managers
         }
     }
 }
-

--- a/Assets/Scripts/Managers/RulesManager.cs
+++ b/Assets/Scripts/Managers/RulesManager.cs
@@ -20,6 +20,11 @@ namespace Assets.Scripts.Managers
             active ??= standardRuleSet ?? new StandardRuleSet();
         }
 
+        public void SetRules(IRuleSet rules)
+        {
+            if (rules != null) active = rules;
+        }
+
         public IRuleSet GetRuleSet()
         {
             if (active == null)

--- a/Assets/Scripts/Managers/RulesManager.cs
+++ b/Assets/Scripts/Managers/RulesManager.cs
@@ -9,13 +9,23 @@ namespace Assets.Scripts.Managers
     /// </summary>
     public class RulesManager : MonoBehaviour
     {
+        [Header("Active Ruleset")]
         [SerializeField] private StandardRuleSet standardRuleSet = new StandardRuleSet();
 
-        // Currently always returns standard rules.
-        // Later tasks may add alternate rule sets.
+        private IRuleSet active;
+
+        private void Awake()
+        {
+            //create new StandardRuleSet if inspector doesn't already have on serialzeied
+            active ??= standardRuleSet ?? new StandardRuleSet();
+        }
+
         public IRuleSet GetRuleSet()
         {
-            return standardRuleSet;
+            if (active == null)
+                active = standardRuleSet ?? new StandardRuleSet();
+
+            return active;
         }
     }
 }

--- a/Assets/Scripts/Managers/RulesManager.cs.meta
+++ b/Assets/Scripts/Managers/RulesManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f0591ff9c70f6941bad4b65e1b941cf

--- a/Assets/Tests/EditMode/RentTests/StandardRentStrategyTests.cs
+++ b/Assets/Tests/EditMode/RentTests/StandardRentStrategyTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 using Assets.Scripts.Managers.Rent;
+using Assets.Scripts.Managers.Rules;
 
 namespace Tests.EditMode.RentTests
 {

--- a/Assets/Tests/PlayMode/RentPlaymodeTests.cs
+++ b/Assets/Tests/PlayMode/RentPlaymodeTests.cs
@@ -1,0 +1,65 @@
+﻿using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Assets.Scripts.Managers.Rent;
+using Assets.Scripts.Managers.Rules;
+
+public class RentPlaymodeTests
+{
+    // creating a mock tile for testing based on the ITileRentInfo
+    private class MockStreet : ITileRentInfo
+    {
+        public string Name { get; }
+        public TileType Type => TileType.Street;
+        public ColorGroup Group { get; }
+        public bool IsMortgaged { get; }
+        public int HouseCount { get; }
+        public int BaseRent { get; }
+        public int[] RentByHouses { get; }
+
+        public MockStreet(
+            string name,
+            ColorGroup group,
+            int baseRent,
+            int houses = 0,
+            bool mortgaged = false,
+            int[] rentTable = null)
+        {
+            Name = name;
+            Group = group;
+            BaseRent = baseRent;
+            HouseCount = houses;
+            IsMortgaged = mortgaged;
+            RentByHouses = rentTable ?? new int[0];
+        }
+    }
+
+    [UnityTest]
+    public IEnumerator RentManager_ComputesCorrectRent_Playmode()
+    {
+        var go = new GameObject("RentManager");
+        var rentManager = go.AddComponent<RentManager>();
+
+        var tenant = ScriptableObject.CreateInstance<Player>();
+        var owner = ScriptableObject.CreateInstance<Player>();
+        tenant.SetMoney(1000);
+        owner.SetMoney(1000);
+
+        //ownership linked to the adapters
+        go.AddComponent<OwnershipServiceAdapter>();
+        go.AddComponent<EconomyAdapter>();
+
+        var tile = new MockStreet("TestProp", ColorGroup.Red, baseRent: 10);
+
+        rentManager.SetOwner(tile, owner);
+        rentManager.TryChargeRent(tenant, tile, diceTotal: 0);
+
+
+        yield return null;
+
+        // isequal seciton
+        Assert.AreEqual(990, tenant.GetMoney());
+        Assert.AreEqual(1010, owner.GetMoney());
+    }
+}

--- a/Assets/Tests/PlayMode/RentPlaymodeTests.cs.meta
+++ b/Assets/Tests/PlayMode/RentPlaymodeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b92fcdc2ff73a8c48864d915a97196ab

--- a/UMLDiagrams/Task408_PropertyOwnership.mmd
+++ b/UMLDiagrams/Task408_PropertyOwnership.mmd
@@ -1,0 +1,53 @@
+classDiagram
+
+    class ITileRentInfo {
+        <<interface>>
+        +Name : string
+        +Type : TileType
+        +Group : ColorGroup
+        +IsMortgaged : bool
+        +HouseCount : int
+        +BaseRent : int
+        +RentByHouses : int[]
+    }
+
+    class IOwnershipService {
+        <<interface>>
+        +GetOwner(tile) Player
+        +CountOwnedInGroup(owner, group) int
+        +CountRailroadsOwned(owner) int
+        +OwnsBothUtilities(owner) bool
+    }
+
+    class OwnershipServiceAdapter {
+        -owners : Dictionary~ITileRentInfo, Player~
+        -ownedByPlayer : Dictionary~Player, HashSet~ITileRentInfo~~
+        +SetOwner(tile, owner)
+        +GetOwner(tile)
+        +CountOwnedInGroup(owner, group)
+        +CountRailroadsOwned(owner)
+        +OwnsBothUtilities(owner)
+    }
+
+    class Player {
+        <<ScriptableObject>>
+        +GetId()
+        +GetMoney()
+        +SetMoney()
+        +SetColor()
+    }
+
+    class RentManager {
+        -ownership : OwnershipServiceAdapter
+        +SetOwner(tile, owner)
+        +TryChargeRent(...)
+    }
+
+    OwnershipServiceAdapter ..|> IOwnershipService
+
+    OwnershipServiceAdapter --> Player : owns
+    OwnershipServiceAdapter --> ITileRentInfo : tracks ownership
+
+    RentManager --> OwnershipServiceAdapter
+
+    Player "1" --> "many" ITileRentInfo : owns >

--- a/UMLDiagrams/Task408_RentStrategy.mmd
+++ b/UMLDiagrams/Task408_RentStrategy.mmd
@@ -1,0 +1,120 @@
+---
+config:
+  layout: elk
+---
+classDiagram
+    class IRentStrategy {
+        <<interface>>
+        +ComputeRent(tile, owner, diceTotal, own, rules) int
+    }
+
+    class ITileRentInfo {
+        <<interface>>
+        +Name : string
+        +Type : TileType
+        +Group : ColorGroup
+        +IsMortgaged : bool
+        +HouseCount : int
+        +BaseRent : int
+        +RentByHouses : int[]
+    }
+
+    class IOwnershipService {
+        <<interface>>
+        +GetOwner(tile) Player
+        +CountOwnedInGroup(owner, group) int
+        +CountRailroadsOwned(owner) int
+        +OwnsBothUtilities(owner) bool
+    }
+
+    class IRentModifier {
+        <<interface>>
+        +Apply(currentRent, tile, tenant, owner) int
+        +IsActive() bool
+    }
+
+    class IRuleSet {
+        <<interface>>
+        +RailroadBaseRent() int
+        +UtilityRentSingleMult() int
+        +UtilityRentBothMult() int
+        +StreetsInGroup(group) int
+    }
+    class StandardRentStrategy {
+        +ComputeRent(...)
+        -StreetRent()
+        -RailroadRent()
+        -UtilityRent()
+    }
+
+    class OwnershipServiceAdapter {
+        -owners : Dictionary
+        -ownedByPlayer : Dictionary
+        +SetOwner(tile, owner)
+        +GetOwner(tile)
+        +CountOwnedInGroup(...)
+        +CountRailroadsOwned(...)
+        +OwnsBothUtilities(...)
+    }
+
+    class RentModifierService {
+        -_mods : List~IRentModifier~
+        +Add(mod)
+        +ApplyAll(...)
+        +DoubleRentOnceForTile(tile)
+        +FreeNextRentForTenant(tenant)
+    }
+
+    class StandardRuleSet {
+        -railroadBase : int
+        -utilitySingle : int
+        -utilityBoth : int
+        +RailroadBaseRent()
+        +UtilityRentSingleMult()
+        +UtilityRentBothMult()
+        +StreetsInGroup()
+    }
+
+    class RentManager {
+        -playerManager : PlayerManager
+        -economy : EconomyAdapter
+        -ownership : OwnershipServiceAdapter
+        -rulesManager : RulesManager
+        -rentModifiers : RentModifierService
+        -rules : IRuleSet
+        -strategy : IRentStrategy
+        +TryChargeRent(tenant, tile, diceTotal)
+        +SetOwner(tile, owner)
+    }
+
+    class RulesManager {
+        -standardRuleSet : StandardRuleSet
+        -active : IRuleSet
+        +GetRuleSet() IRuleSet
+        +SetRules(rules)
+    }
+
+    class EconomyAdapter {
+        +Transfer(from, to, amount) bool
+    }
+
+    class Player {
+        <<ScriptableObject>>
+        +GetId()
+        +GetMoney()
+        +SetMoney()
+    }
+
+    RentManager --> IRentStrategy
+    RentManager --> IRuleSet
+    RentManager --> IOwnershipService
+    RentManager --> RentModifierService
+    RentManager --> EconomyAdapter
+    RentManager --> RulesManager
+
+    StandardRentStrategy ..|> IRentStrategy
+    OwnershipServiceAdapter ..|> IOwnershipService
+    StandardRuleSet ..|> IRuleSet
+
+    RentModifierService --> IRentModifier
+    RentManager --> Player : tenant/owner


### PR DESCRIPTION
US402: As a player, I want rent and tile effects to update correctly under all rules strategies so that they properly interact and it feels consistent with Monoploy rules

Task#403: Finalize StandardRentStrategy logic
Task#404: Add RuleSet override for alternative rules, can be placeholder
Task#405: Integrate ownership service into RentManager
Task#406: Update card and TileEffect resolution for rent modifiers
Task#407: Create playmode tests for rent across all tiles
Task#408: Update Property Ownership and Rent strategy class diagrams