### PR TITLE
US839: As a developer, I want InputManager to validate its camera dependency on startup...

### DIFF
--- a/Assets/Scripts/Managers/InputManager.cs
+++ b/Assets/Scripts/Managers/InputManager.cs
@@ -1,4 +1,5 @@
 ﻿using Interactable;
+using Logging;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -9,6 +10,19 @@ namespace Managers
         [SerializeField] private Camera mainCamera;
 
         private IHoverable currentHovered;
+
+        private void Start()
+        {
+            if (!mainCamera)
+                mainCamera = Camera.main;
+
+            if (mainCamera) return;
+            
+            Logging.Logger.Error("InputManager.Start",
+                "Unable to find camera in scene!",
+                LogCategory.UI);
+            Destroy(this);
+        }
         
         private void Update()
         {


### PR DESCRIPTION
US839: As a developer, I want `InputManager` to validate its camera dependency on startup, so that misconfiguration fails loudly and early rather than throwing cryptic null reference errors at runtime.

Based on audit findings: [Audit Document](https://docs.google.com/document/d/1WJzDd5SaGqytxkzNf9bnYngZ0VAfcHcN5SSD1_PxS5c/edit?usp=sharing)

This adds a `Start()` method to `InputManager` that checks for the serialized camera reference. If none exists, it checks for the scene's 'main camera', and references that instead. If that also fails, it means there's no cameras in the scene properly configured, and the `InputManager` logs an error and destroys itself, rather than allowing exceptions to happen in `Update()`.