### PR TITLE
US771

### DIFF
--- a/Assets/Scripts/Managers/JailManager.cs
+++ b/Assets/Scripts/Managers/JailManager.cs
@@ -1,6 +1,0 @@
-using UnityEngine;
-
-public class JailManager
-{
-    
-}

--- a/Assets/Scripts/Managers/JailManager.cs.meta
+++ b/Assets/Scripts/Managers/JailManager.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: 028d1ac8d6ebb924d98a20f91fa729b2

--- a/Documentation/AuditDiagrams/Completed Audit Files/Jail Manager Integration Audit.pdf
+++ b/Documentation/AuditDiagrams/Completed Audit Files/Jail Manager Integration Audit.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebc8008b41fa2bb6caca8780500eb264753e26d4451c127c3a9488dc0a6998f4
+size 114709


### PR DESCRIPTION
Completes US771 which removes the Manager/JailManager.cs file from the project since it had no logic/code. 

Completes Tasks:
- Remove Managers/JailManagers.cs file (US 772)
- Confirm all unit tests still pass and no compile time errors occur (US 773)

