### PR TITLE
Us900 Jail State Capture

### DIFF
--- a/Assets/Scripts/Data/Player.cs
+++ b/Assets/Scripts/Data/Player.cs
@@ -38,6 +38,11 @@ public class Player : ScriptableObject
         return this.id;
     }
 
+    public bool IsInJail()
+    {
+        return inJail;
+    }
+
     public void SetPName(string name)
     {
         this.p_Name = name;

--- a/Assets/Scripts/Managers/PlayerControllers/AIPlayerController.cs
+++ b/Assets/Scripts/Managers/PlayerControllers/AIPlayerController.cs
@@ -1,4 +1,5 @@
 ﻿using AIBehavior;
+using Assets.Scripts.Events.EventChannelTypes;
 using Assets.Scripts.Managers.TurnFlow;
 using Data;
 using Events.EventDataStructures;
@@ -46,8 +47,9 @@ namespace Managers.PlayerControllers
             UpgradeRequestEventChannel upgradeRequest,
             IntEventChannel bankruptPlayer,
             TurnActionRequestEventChannel turnActionRequest,
-            TurnActionResultEventChannel turnActionResult) 
-            : base(player, turnStarted, turnEnded, purchaseRequest, chargeOwnershipFee, passedGoPayment, upgradeRequest, turnActionRequest, turnActionResult, bankruptPlayer)
+            TurnActionResultEventChannel turnActionResult,
+            JailStateChangedEventChannel jailStateChanged) 
+            : base(player, turnStarted, turnEnded, purchaseRequest, chargeOwnershipFee, passedGoPayment, upgradeRequest, turnActionRequest, turnActionResult, bankruptPlayer, jailStateChanged)
         {
             // load in behavior / personality
             weights = aiBehaviorWeights;

--- a/Assets/Scripts/Managers/PlayerControllers/HumanPlayerController.cs
+++ b/Assets/Scripts/Managers/PlayerControllers/HumanPlayerController.cs
@@ -3,7 +3,6 @@ using Assets.Scripts.Managers.TurnFlow;
 using Events.EventDataStructures;
 using Events.EventDataStructures.UI;
 using Logging;
-using UnityEngine;
 using Logger = Logging.Logger;
 
 

--- a/Assets/Scripts/Managers/PlayerControllers/HumanPlayerController.cs
+++ b/Assets/Scripts/Managers/PlayerControllers/HumanPlayerController.cs
@@ -47,8 +47,9 @@ namespace Managers.PlayerControllers
             UpgradeRequestEventChannel upgradeRequest,
             IntEventChannel bankruptPlayer,
             TurnActionRequestEventChannel turnActionRequest,
-            TurnActionResultEventChannel turnActionResult) 
-            : base(player, turnStarted, turnEnded, purchaseRequest, chargeOwnershipFee, passedGoPayment, upgradeRequest, turnActionRequest, turnActionResult, bankruptPlayer)
+            TurnActionResultEventChannel turnActionResult,
+            JailStateChangedEventChannel jailStateChanged) 
+            : base(player, turnStarted, turnEnded, purchaseRequest, chargeOwnershipFee, passedGoPayment, upgradeRequest, turnActionRequest, turnActionResult, bankruptPlayer, jailStateChanged)
         {
             // human controller specific setup goes here
             uiActivationEventChannel = uiActivation;

--- a/Assets/Scripts/Managers/PlayerControllers/PlayerController.cs
+++ b/Assets/Scripts/Managers/PlayerControllers/PlayerController.cs
@@ -51,8 +51,7 @@ namespace Managers.PlayerControllers
             TurnActionRequestEventChannel turnActionRequest,
             TurnActionResultEventChannel  turnActionResult,
             IntEventChannel bankruptPlayer,
-            JailStateChangedEventChannel jailStateChanged,
-            IntEventChannel forcedTurnAdvance)
+            JailStateChangedEventChannel jailStateChanged)
         {
             controlledPlayer = player ?? throw new System.ArgumentNullException(nameof(player));
             turnStartedEventChannel = turnStarted ?? throw new System.ArgumentNullException(nameof(turnStarted));
@@ -69,7 +68,6 @@ namespace Managers.PlayerControllers
             upgradeRequestEventChannel = upgradeRequest ?? throw new System.ArgumentNullException(nameof(upgradeRequest));
             bankruptPlayerEventChannel = bankruptPlayer ?? throw new System.ArgumentException(nameof(bankruptPlayer));
             jailStateChangedEventChannel = jailStateChanged ?? throw new System.ArgumentNullException(nameof(jailStateChanged));
-            forcedTurnAdvanceEventChannel = forcedTurnAdvance ?? throw new System.ArgumentNullException(nameof(forcedTurnAdvance));
         }
         
         /// <summary>
@@ -208,28 +206,17 @@ namespace Managers.PlayerControllers
             if (jailEvent.player.GetId() != controlledPlayer.GetId())
                 return;
 
-            // jail state change for the controlled player
             controlledPlayer.SetInJail(jailEvent.inJail);
             controlledPlayer.SetJailTurns(jailEvent.jailTurns);
 
-            Logger.Info("PlayerController.HandleJailStateChanged",
+            Logging.Logger.Info("PlayerController.HandleJailStateChanged",
                 $"Updated jail state for {controlledPlayer.GetPName()}: inJail={jailEvent.inJail}, jailTurns={jailEvent.jailTurns}.",
                 LogCategory.Gameplay,
                 this);
 
-            // Being sent to jail during resolution should end the turn immediately.
-            // This is not a normal player action, so it should not go through TurnActionRequest.
             if (isMyTurn && jailEvent.inJail)
             {
-                // Clear pending callbacks because the current turn is being interrupted.
                 pendingActions.Clear();
-
-                forcedTurnAdvanceEventChannel?.RaiseEvent(controlledPlayer.GetId());
-                Logger.Info("PlayerController.HandleJailStateChanged",
-                    $"{controlledPlayer.GetPName()} was sent to jail during their turn. Raised forced turn advance event.",
-                    LogCategory.Gameplay,
-                    this);
-
                 isMyTurn = false;
             }
         }

--- a/Assets/Scripts/Managers/PlayerControllers/PlayerController.cs
+++ b/Assets/Scripts/Managers/PlayerControllers/PlayerController.cs
@@ -28,7 +28,6 @@ namespace Managers.PlayerControllers
         protected UpgradeRequestEventChannel upgradeRequestEventChannel;
         protected IntEventChannel bankruptPlayerEventChannel;
         protected JailStateChangedEventChannel jailStateChangedEventChannel;
-        protected IntEventChannel forcedTurnAdvanceEventChannel;
 
 
         // These handle the callbacks for when a turn action request is allowed or denied from the TurnFlowCoordinator.

--- a/Assets/Scripts/Managers/PlayerControllers/PlayerController.cs
+++ b/Assets/Scripts/Managers/PlayerControllers/PlayerController.cs
@@ -1,4 +1,6 @@
-﻿using Assets.Scripts.Managers.TurnFlow;
+﻿using Assets.Scripts.Events.EventChannelTypes;
+using Assets.Scripts.Events.EventDataStructures;
+using Assets.Scripts.Managers.TurnFlow;
 using Logging;
 using System;
 using System.Collections.Generic;
@@ -21,11 +23,12 @@ namespace Managers.PlayerControllers
         protected ChargeOwnershipFeeEventChannel chargeOwnershipFeeEventChannel;
         protected PayPlayerEventChannel passedGoPaymentChannel;
         protected CardDrawnEventChannel cardDrawnEventChannel;
-        // event channels to validate turn actions against the current turn phase.
         protected TurnActionRequestEventChannel turnActionRequestEventChannel;
         protected TurnActionResultEventChannel turnActionResultEventChannel;
         protected UpgradeRequestEventChannel upgradeRequestEventChannel;
         protected IntEventChannel bankruptPlayerEventChannel;
+        protected JailStateChangedEventChannel jailStateChangedEventChannel;
+        protected IntEventChannel forcedTurnAdvanceEventChannel;
 
 
         // These handle the callbacks for when a turn action request is allowed or denied from the TurnFlowCoordinator.
@@ -47,7 +50,9 @@ namespace Managers.PlayerControllers
             UpgradeRequestEventChannel upgradeRequest,
             TurnActionRequestEventChannel turnActionRequest,
             TurnActionResultEventChannel  turnActionResult,
-            IntEventChannel bankruptPlayer)
+            IntEventChannel bankruptPlayer,
+            JailStateChangedEventChannel jailStateChanged,
+            IntEventChannel forcedTurnAdvance)
         {
             controlledPlayer = player ?? throw new System.ArgumentNullException(nameof(player));
             turnStartedEventChannel = turnStarted ?? throw new System.ArgumentNullException(nameof(turnStarted));
@@ -62,7 +67,9 @@ namespace Managers.PlayerControllers
             turnActionResultEventChannel = turnActionResult ?? 
                 throw new System.ArgumentNullException(nameof(turnActionResult));
             upgradeRequestEventChannel = upgradeRequest ?? throw new System.ArgumentNullException(nameof(upgradeRequest));
-            IntEventChannel bankruptPlayerEventChannel = bankruptPlayer ?? throw new System.ArgumentException(nameof(bankruptPlayer));
+            bankruptPlayerEventChannel = bankruptPlayer ?? throw new System.ArgumentException(nameof(bankruptPlayer));
+            jailStateChangedEventChannel = jailStateChanged ?? throw new System.ArgumentNullException(nameof(jailStateChanged));
+            forcedTurnAdvanceEventChannel = forcedTurnAdvance ?? throw new System.ArgumentNullException(nameof(forcedTurnAdvance));
         }
         
         /// <summary>
@@ -73,6 +80,7 @@ namespace Managers.PlayerControllers
         {
             turnStartedEventChannel?.Subscribe(CatchTurnStartedEvent);
             turnActionResultEventChannel?.Subscribe(OnTurnActionResult);
+            jailStateChangedEventChannel?.Subscribe(HandleJailStateChanged);
         }
 
         /// <summary>
@@ -84,6 +92,7 @@ namespace Managers.PlayerControllers
         {
             turnStartedEventChannel?.Unsubscribe(CatchTurnStartedEvent);
             turnActionResultEventChannel?.Unsubscribe(OnTurnActionResult);
+            jailStateChangedEventChannel?.Unsubscribe(HandleJailStateChanged);
             pendingActions.Clear();
             isMyTurn = false;
         }
@@ -183,6 +192,46 @@ namespace Managers.PlayerControllers
                 TurnActionType.CompleteResolution,
                 onAllowed ?? (() => { }),
                 onDenied);
+        }
+
+        /// <summary>
+        /// Applies jail state changes to the controlled player.
+        /// If this player is actively taking their turn and is sent to jail,
+        /// raise a forced turn advance event instead of directly
+        /// calling TurnFlowCoordinator.
+        /// </summary>
+        protected virtual void HandleJailStateChanged(JailStateChangedEvent jailEvent)
+        {
+            if (jailEvent == null || jailEvent.player == null)
+                return;
+
+            if (jailEvent.player.GetId() != controlledPlayer.GetId())
+                return;
+
+            // jail state change for the controlled player
+            controlledPlayer.SetInJail(jailEvent.inJail);
+            controlledPlayer.SetJailTurns(jailEvent.jailTurns);
+
+            Logger.Info("PlayerController.HandleJailStateChanged",
+                $"Updated jail state for {controlledPlayer.GetPName()}: inJail={jailEvent.inJail}, jailTurns={jailEvent.jailTurns}.",
+                LogCategory.Gameplay,
+                this);
+
+            // Being sent to jail during resolution should end the turn immediately.
+            // This is not a normal player action, so it should not go through TurnActionRequest.
+            if (isMyTurn && jailEvent.inJail)
+            {
+                // Clear pending callbacks because the current turn is being interrupted.
+                pendingActions.Clear();
+
+                forcedTurnAdvanceEventChannel?.RaiseEvent(controlledPlayer.GetId());
+                Logger.Info("PlayerController.HandleJailStateChanged",
+                    $"{controlledPlayer.GetPName()} was sent to jail during their turn. Raised forced turn advance event.",
+                    LogCategory.Gameplay,
+                    this);
+
+                isMyTurn = false;
+            }
         }
     }
 }

--- a/Assets/Scripts/Managers/PlayerManager.cs
+++ b/Assets/Scripts/Managers/PlayerManager.cs
@@ -28,6 +28,7 @@ public class PlayerManager : MonoBehaviour
     [SerializeField] public ActionResolvedEventChannel actionResolvedEventChannel;
     [SerializeField] public UpgradeRequestEventChannel upgradeRequestEventChannel;
     [SerializeField] public IntEventChannel bankruptcyEventChannel;
+    [SerializeField] public JailStateChangedEventChannel jailEventChannel;
 
     public List<PlayerController> playerControllers = new();
     
@@ -71,7 +72,8 @@ public class PlayerManager : MonoBehaviour
                     upgradeRequestEventChannel,
                     bankruptcyEventChannel,
                     turnActionRequestEventChannel,
-                    turnActionResultEventChannel);
+                    turnActionResultEventChannel,
+                    jailEventChannel);
             }
             else
             {
@@ -88,7 +90,8 @@ public class PlayerManager : MonoBehaviour
                     upgradeRequestEventChannel,
                     bankruptcyEventChannel,
                     turnActionRequestEventChannel,
-                    turnActionResultEventChannel);
+                    turnActionResultEventChannel,
+                    jailEventChannel);
             }
 
             playerController.Subscribe();

--- a/Assets/Scripts/Managers/TurnFlow/TurnFlowCoordinator.cs
+++ b/Assets/Scripts/Managers/TurnFlow/TurnFlowCoordinator.cs
@@ -1,4 +1,5 @@
-﻿using Assets.Scripts.Managers.TurnOrder;
+﻿using Assets.Scripts.Events.EventChannelTypes;
+using Assets.Scripts.Managers.TurnOrder;
 using Logging;
 using UnityEngine;
 
@@ -139,7 +140,7 @@ namespace Assets.Scripts.Managers.TurnFlow
                 return;
 
             int playerId = request.player.GetId();
-            bool allowed = IsAllowed(playerId, request.action);
+            bool allowed = IsAllowed(request.action, request.player);
 
             turnActionResultChannel?.RaiseEvent(new TurnActionResult
             {
@@ -181,21 +182,23 @@ namespace Assets.Scripts.Managers.TurnFlow
             OnTurnActionRequested(request);
         }
 
-        private bool IsAllowed(int playerId, TurnActionType action)
+        private bool IsAllowed(TurnActionType action, Player player)
         {
+            if (player.GetId() != ActivePlayer) return false;
 
-            if (playerId != ActivePlayer) return false;
+            if (player != null && player.IsInJail())
+                return action == TurnActionType.EndTurn;
+            
 
             return action switch
             {
                 TurnActionType.RollDice => Phase == TurnPhase.AwaitingRoll,
-                // upgrade at any point in the player's turn
                 TurnActionType.BuyProperty => Phase == TurnPhase.AwaitingResolution
-                                                || (Phase == TurnPhase.Completed && awaitingEndTurn),
+                                              || (Phase == TurnPhase.Completed && awaitingEndTurn),
                 TurnActionType.ModifyProperty => Phase == TurnPhase.AwaitingRoll
-                                                || Phase == TurnPhase.AwaitingMovement
-                                                || Phase == TurnPhase.AwaitingResolution
-                                                || (Phase == TurnPhase.Completed && awaitingEndTurn),
+                                                 || Phase == TurnPhase.AwaitingMovement
+                                                 || Phase == TurnPhase.AwaitingResolution
+                                                 || (Phase == TurnPhase.Completed && awaitingEndTurn),
                 TurnActionType.CompleteResolution => Phase == TurnPhase.AwaitingResolution,
                 TurnActionType.EndTurn => Phase == TurnPhase.Completed && awaitingEndTurn,
                 _ => false


### PR DESCRIPTION
Context
A player can land on Go To Jail during any turn, including the first. The space resolution fires correctly, but the method responsible for setting the Player’s jail state on their data object was removed during the refactor, meaning the game has no way to actually flag a player as jailed. Without this, jail turn handling cannot be built or tested.

Description
The base PlayerController class listens for the JailStateChanged event raised by the Go To Launch Pad space or cards and correctly updates the player’s jail state, ending the turn immediately if they remain in jail.

Scope
Restore the method for setting jail state on the Player data object inside PlayerController
Sending a player to jail bypasses normal End Turn validation in TurnFlowCoordinator, since the turn ends as a result of space resolution rather than a player action (possible race condition on events)