### PR TITLE
Fixes #182 : missing player models when running from SampleScene

### DIFF
--- a/Assets/Scripts/Managers/Piece.cs
+++ b/Assets/Scripts/Managers/Piece.cs
@@ -8,7 +8,7 @@ using System.Collections;
 /// </summary>
 public class Piece : MonoBehaviour
 {
-      [SerializeField] private Color pieceColor = Color.white;
+    [SerializeField] private Color pieceColor = Color.white;
     [SerializeField] private float moveSpeed = 3f;
     [SerializeField] private BooleanEventChannel pieceMoveCompletedEventChannel;
 
@@ -42,6 +42,11 @@ public class Piece : MonoBehaviour
         if (modelPrefab != null)
         {
             SetModel(modelPrefab);
+        }
+        else // backup to the default cylinder model
+        {
+            meshRenderer.enabled = true;
+            transform.Rotate(90,0,0);
         }
     }
 

--- a/Assets/Scripts/UI/HUD/PlayerPanelController.cs
+++ b/Assets/Scripts/UI/HUD/PlayerPanelController.cs
@@ -43,8 +43,17 @@ public class PlayerPanelController : UIPanelBase
         InvokeRepeating(nameof(UpdatePlayerUI), pollRate, pollRate);
     }
 
-    private void OnTurnStarted(TurnStartedEvent tse) => currentPlayerId = tse.playerId;
-    
+    private void OnTurnStarted(TurnStartedEvent tse)
+    {
+        currentPlayerId = tse.playerId;
+
+        var player = PlayerManager.GetInstance().GetPlayer(currentPlayerId);
+        Logging.Logger.Info("PlayerPanelController.DisplayCurrentPlayer",
+            $"Current Player: {player.GetPName()} with ${player.GetMoney()}",
+            LogCategory.UI,
+            this);
+    }
+
     private void UpdatePlayerUI()
     {
         var player = PlayerManager.GetInstance().GetPlayer(currentPlayerId);
@@ -65,9 +74,5 @@ public class PlayerPanelController : UIPanelBase
 
         SetTextSafe(playerNameText, $"Player: {name}");
         SetTextSafe(playerMoneyText, $"Money: {money}");
-        Logging.Logger.Info("PlayerPanelController.DisplayCurrentPlayer",
-            $"Current Player: {name} with ${money}",
-            LogCategory.UI,
-            this);
     }
 }


### PR DESCRIPTION
When player models were added, their original mesh renderer was disabled in favor of the new models. However, the default constructed players that are built when you run from the sample scene for testing don't have models associated, so they would cease rendering.

The solution is to have a fallback for when no model exists, which re-enables the Cylinder mesh and sets the correct rotation.