### PR TITLE
Fixes #186 : Adds slight delay and smooth fade to On Hover UI

### DIFF
--- a/Assets/Prefabs/Panels/HoverPanelUI.prefab
+++ b/Assets/Prefabs/Panels/HoverPanelUI.prefab
@@ -1834,7 +1834,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &4660390705980771149
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1866,6 +1866,31 @@ MonoBehaviour:
   m_EditorClassIdentifier: PsycheOpoly.Runtime::OnHoverUI
   spaceHoverEventChannel: {fileID: 11400000, guid: 5262a742445453a4495cf054a06d45c5, type: 2}
   onSpaceExitEventChannel: {fileID: 11400000, guid: a85c0b96db3339442a55a6435a1d7263, type: 2}
+  easeCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 1
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  fadeTime: 1
   canvasGroup: {fileID: 4486295716104875362}
   titleText: {fileID: 3941118106923312164}
   bodyText: {fileID: 5185679715491331673}

--- a/Assets/Scripts/UI/Board/OnHoverUI.cs
+++ b/Assets/Scripts/UI/Board/OnHoverUI.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Text;
 using Events.EventDataStructures;
 using TMPro;
@@ -9,6 +10,11 @@ public class OnHoverUI : MonoBehaviour
     [Header("Event Channels")]
     [SerializeField] private SpaceHoverEventChannel spaceHoverEventChannel;
     [SerializeField] private BooleanEventChannel onSpaceExitEventChannel;
+
+    [Header("Animation Settings")] 
+    [SerializeField] private float delayTime = 0.5f;
+    [SerializeField] private AnimationCurve easeCurve;
+    [SerializeField] private float fadeTime = 1f;
 
     [Header("UI References")]
     [SerializeField] private CanvasGroup canvasGroup;
@@ -23,10 +29,13 @@ public class OnHoverUI : MonoBehaviour
     [SerializeField] private TMP_Text costValueText;
     [SerializeField] private TMP_Text rentValueText;
     [SerializeField] private TMP_Text ownerValueText;
-
+    
+    private float currentTime = 0f;
+    private bool isHidden = true;
+    
     private void Awake()
     {
-        Hide();
+        StartCoroutine(Hide());
     }
 
     private void OnEnable()
@@ -45,7 +54,7 @@ public class OnHoverUI : MonoBehaviour
     {
         if (e == null || e.spaceData == null)
         {
-            Hide();
+            StartCoroutine(Hide());
             return;
         }
 
@@ -120,7 +129,8 @@ public class OnHoverUI : MonoBehaviour
             }
         }
 
-        Show();
+        StopAllCoroutines();
+        StartCoroutine(Show());
     }
 
     private static void SetRow(TMP_Text valueText, bool visible)
@@ -141,22 +151,48 @@ public class OnHoverUI : MonoBehaviour
 
     private void OnSpaceExit(bool _)
     {
-        Hide();
+        StopAllCoroutines();
+        StartCoroutine(Hide());
     }
 
-    private void Show()
+    private IEnumerator Show()
     {
-        if (canvasGroup == null) return;
-        canvasGroup.alpha = 1f;
+        if (canvasGroup == null) yield break;
+        
         canvasGroup.blocksRaycasts = true;
         canvasGroup.interactable = true;
+
+        if (isHidden)
+        {
+            yield return new WaitForSeconds(delayTime);
+            isHidden = false;
+        }
+
+        while (currentTime < fadeTime)
+        {
+            canvasGroup.alpha = easeCurve.Evaluate(currentTime / fadeTime);
+            yield return new WaitForEndOfFrame();
+            currentTime += Time.deltaTime;
+        }
+
+        canvasGroup.alpha = 1f;
     }
 
-    private void Hide()
+    private IEnumerator Hide()
     {
-        if (canvasGroup == null) return;
-        canvasGroup.alpha = 0f;
+        if (canvasGroup == null) yield break;
+        
         canvasGroup.blocksRaycasts = false;
         canvasGroup.interactable = false;
+        
+        while (currentTime > 0f)
+        {
+            canvasGroup.alpha = easeCurve.Evaluate(currentTime / fadeTime);
+            yield return new WaitForEndOfFrame();
+            currentTime -= Time.deltaTime;
+        }
+        
+        canvasGroup.alpha = 0f;
+        isHidden = true;
     }
 }


### PR DESCRIPTION
This really simply sets a fade animation for the OnHoverUI so it doesnt flicker when you mouse over it to simply play the game. I introduced a slight delay in the Show coroutine so that it only fades in when the mouse stays hovered for about 1/2 a second, which means just moving the mouse around doesn't immediately flash stuff on the screen.

Closes #186 